### PR TITLE
feat: serve ui from go server [WD-11656]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ ui/node_modules
 ui/playwright-report
 test-results
 haproxy-local.cfg
+.vscode
+api/static
+*__debug*

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ default: build
 # Build targets.
 .PHONY: build
 build:
+	cd ui && yarn build
+	cd api && go generate
 	go install -v ./cmd/lxd-site-mgr
 	go install -v ./cmd/lxd-site-mgrd
 

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -10,4 +10,7 @@ import (
 var Endpoints = []rest.Endpoint{
 	siteCmd,
 	sitesCmd,
+	uiCmd,
+	uiAssetsCmd,
+	uiImgCmd,
 }

--- a/api/ui.go
+++ b/api/ui.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+
+	"github.com/canonical/lxd/lxd/response"
+
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/state"
+)
+
+// Copy built UI files to the static directory. Then embed the static directory in go binary.
+//
+//go:generate cp -r ../ui/build/ui ./static
+//go:embed static
+var UI embed.FS
+
+var uiCmd = rest.Endpoint{
+	Path: "ui",
+	Get:  rest.EndpointAction{Handler: serveUI, AllowUntrusted: true},
+}
+
+var uiAssetsCmd = rest.Endpoint{
+	Path: "ui/assets/{asset}",
+	Get:  rest.EndpointAction{Handler: serveUI, AllowUntrusted: true},
+}
+
+var uiImgCmd = rest.Endpoint{
+	Path: "ui/assets/img/{image}",
+	Get:  rest.EndpointAction{Handler: serveUI, AllowUntrusted: true},
+}
+
+func serveUI(s *state.State, r *http.Request) response.Response {
+	uiFS, err := fs.Sub(UI, "static")
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	fileServer := http.StripPrefix("/1.0/ui", http.FileServer(http.FS(uiFS)))
+
+	serverUiHandler := func(w http.ResponseWriter) error {
+		// microcluster sets the Content-Type header to application/json by default. We need to remove it to serve the UI.
+		w.Header().Del("Content-Type")
+		// Disables the FLoC (Federated Learning of Cohorts) feature on the browser,
+		// preventing the current page from being included in the user's FLoC calculation.
+		// FLoC is a proposed replacement for third-party cookies to enable interest-based advertising.
+		w.Header().Set("Permissions-Policy", "interest-cohort=()")
+		// Prevents the browser from trying to guess the MIME type, which can have security implications.
+		// This tells the browser to strictly follow the MIME type provided in the Content-Type header.
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		// Restricts the page from being displayed in a frame, iframe, or object to avoid click jacking attacks,
+		// but allows it if the site is navigating to the same origin.
+		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		// Sets the Content Security Policy (CSP) for the page, which helps mitigate XSS attacks and data injection attacks.
+		// The policy allows loading resources (scripts, styles, images, etc.) only from the same origin ('self'), data URLs, and all subdomains of ubuntu.com.
+		w.Header().Set("Content-Security-Policy", "default-src 'self' data: https://*.ubuntu.com https://*.canonical.com; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'")
+
+		fileServer.ServeHTTP(w, r)
+		return nil
+	}
+
+	return response.ManualResponse(serverUiHandler)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/canonical/lxd-site-manager
 go 1.22.3
 
 require (
-	github.com/canonical/lxd v0.0.0-20240512132740-b2ede506d347
-	github.com/canonical/microcluster v0.0.0-20240513165320-9d2f771ea436
+	github.com/canonical/lxd v0.0.0-20240604090332-b7e7ce7b97c2
+	github.com/canonical/microcluster v0.0.0-20240603082009-d23c4306e691
+	github.com/gorilla/mux v1.8.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.8.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -18,7 +20,6 @@ require (
 	github.com/fvbommel/sortorder v1.1.0 // indirect
 	github.com/google/renameio v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/schema v1.3.0 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gorilla/websocket v1.5.1 // indirect
@@ -37,13 +38,12 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/zitadel/oidc/v2 v2.12.0 // indirect
-	golang.org/x/crypto v0.22.0 // indirect
-	golang.org/x/net v0.24.0 // indirect
+	golang.org/x/crypto v0.23.0 // indirect
+	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.20.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/term v0.20.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -52,10 +52,10 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/canonical/go-dqlite v1.21.0 h1:4gLDdV2GF+vg0yv9Ff+mfZZNQ1JGhnQ3GnS2GeZPHfA=
 github.com/canonical/go-dqlite v1.21.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
-github.com/canonical/lxd v0.0.0-20240512132740-b2ede506d347 h1:3SSlbaKRjndhCMfqXtFkpsFXGcFEwtDUWfcpC6/lszo=
-github.com/canonical/lxd v0.0.0-20240512132740-b2ede506d347/go.mod h1:4/wS6K3d+00kqwBrUs0I89i3oRN9zNmFE+QkI8wEaz0=
-github.com/canonical/microcluster v0.0.0-20240513165320-9d2f771ea436 h1:SWMZRY5N89y0TxHs3mUrA/TZK26jpVWvjWwmUathTNs=
-github.com/canonical/microcluster v0.0.0-20240513165320-9d2f771ea436/go.mod h1:e+5/TvKFuQaphV6Aaw7nGDZi2TJ6fls04FV9kBOjcDA=
+github.com/canonical/lxd v0.0.0-20240604090332-b7e7ce7b97c2 h1:IPI5JvTM7DvciGBzGmz+ZRoXMKwERTkSLoB07iNTmYY=
+github.com/canonical/lxd v0.0.0-20240604090332-b7e7ce7b97c2/go.mod h1:9X9F9BKR38g7q5KKEwNUtBegu+PQ31XOYL1sCbeN50Y=
+github.com/canonical/microcluster v0.0.0-20240603082009-d23c4306e691 h1:wIKi1I0ahZ0Frc+4VuQIayiN8cVSa2IogU3w2938gd8=
+github.com/canonical/microcluster v0.0.0-20240603082009-d23c4306e691/go.mod h1:e+5/TvKFuQaphV6Aaw7nGDZi2TJ6fls04FV9kBOjcDA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -345,8 +345,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
-golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
-golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
+golang.org/x/crypto v0.23.0 h1:dIJU/v2J8Mdglj/8rJ6UUOM3Zc9zLZxVZwwxMooUSAI=
+golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -421,8 +421,8 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
-golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=
-golang.org/x/net v0.24.0/go.mod h1:2Q7sJY5mzlzWjKtYUEXSlBWCdyaioyXzRB2RtU8KVE8=
+golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
+golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/ui/index.html
+++ b/ui/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <title>LXD Site Manager</title>
-    <link rel="shortcut icon" href="/assets/img/favicon-32x32.png" type="image/x-icon">
+    <link rel="shortcut icon" href="/1.0/ui/assets/img/favicon-32x32.png" type="image/x-icon">
 
     <script>const global = globalThis;</script>
   </head>

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules yarn-error.log *.log build/ .jekyll-metadata .bundle playwright-report test-results build",
-    "build": "npx vite build --emptyOutDir",
+    "build": "VITE_BASE_URL=/1.0/ui/ npx vite build --emptyOutDir",
     "format-js-eslint": "eslint 'src/**/*.{json,jsx,tsx,ts}' 'tests/**/*.ts' --fix",
     "format-js-prettier": "prettier 'src/**/*.{json,jsx,tsx,ts}' 'tests/**/*.ts' --write",
     "format-js": "yarn format-js-eslint && yarn format-js-prettier",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,8 +7,8 @@ const App: FC = () => {
   return (
     <Suspense fallback={<div>Loading</div>}>
       <Routes>
-        <Route path="/" element={<Navigate to="/ui" replace={true} />} />
-        <Route path="/ui" element={<SiteList />} />
+        <Route path="/" element={<Navigate to="/1.0/ui" replace={true} />} />
+        <Route path="/1.0/ui" element={<SiteList />} />
       </Routes>
     </Suspense>
   );

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -4,6 +4,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [tsconfigPaths(), react()],
+  base: process.env.VITE_BASE_URL || "/",
   server: {
     port: 3000,
     proxy: {
@@ -17,5 +18,10 @@ export default defineConfig({
   build: {
     outDir: "./build/ui",
     minify: "esbuild",
+  },
+  experimental: {
+    renderBuiltUrl(filename: string) {
+      return "/1.0/ui/" + filename;
+    },
   },
 });


### PR DESCRIPTION
## Done

1. added api endpoints to serve ui static assets
2. updated ui build configs to include `/1.0/ui` as base prefix for routing

## Notes
1. The static assets will be copied from the ui directory and embedded in the go binary during compilation
2. multiple endpoints must be registered for various static file paths due to limitation from microcluster where api endpoints are registered individually behind `/1.0` prefix.
3. For development, the UI is served from vite dev server which can be reached on `http://0.0.0.0:8414/`. For testing and production environments (future), the UI is served from each cluster members API e.g. `https://0.0.0.0:9001/1.0/ui`