### PR TITLE
serve index for component paths

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,12 +11,12 @@ var siteManagementListener = rest.Server{
 	Resources: []rest.Resources{
 		{
 			PathPrefix: types.NoPrefix,
-			Endpoints: []rest.Endpoint{
-				uiRootCmd,
-				uiCmd,
-				uiAssetsCmd,
-				uiImgCmd,
-			},
+			Endpoints: append(
+				[]rest.Endpoint{
+					uiRootCmd,
+				},
+				generateUIEndpoints()...,
+			),
 		},
 		{
 			PathPrefix: types.APIVersionPrefix,

--- a/internal/api/ui.go
+++ b/internal/api/ui.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"io/fs"
 	"net/http"
+	"os"
 
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/microcluster/rest"
@@ -21,19 +22,22 @@ var uiRootCmd = rest.Endpoint{
 	Get:  rest.EndpointAction{Handler: redirectToUI, AllowUntrusted: true},
 }
 
-var uiCmd = rest.Endpoint{
-	Path: "ui",
-	Get:  rest.EndpointAction{Handler: serveUI, AllowUntrusted: true},
+var uiServeRoutes = []string{
+	"ui",
+	"ui/assets/{asset}",
+	"ui/assets/img/{image}",
 }
 
-var uiAssetsCmd = rest.Endpoint{
-	Path: "ui/assets/{asset}",
-	Get:  rest.EndpointAction{Handler: serveUI, AllowUntrusted: true},
-}
+func generateUIEndpoints() []rest.Endpoint {
+	var uiEndpoints []rest.Endpoint
+	for _, route := range uiServeRoutes {
+		uiEndpoints = append(uiEndpoints, rest.Endpoint{
+			Path: route,
+			Get:  rest.EndpointAction{Handler: serveUI, AllowUntrusted: true},
+		})
+	}
 
-var uiImgCmd = rest.Endpoint{
-	Path: "ui/assets/img/{image}",
-	Get:  rest.EndpointAction{Handler: serveUI, AllowUntrusted: true},
+	return uiEndpoints
 }
 
 func redirectToUI(s *state.State, r *http.Request) response.Response {
@@ -46,7 +50,13 @@ func serveUI(s *state.State, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	fileServer := http.StripPrefix("/ui", http.FileServer(http.FS(uiFS)))
+	// Need to implement the http.FileSystem interface to serve the UI files.
+	// Need custom Open method to serve index.html when the requested file is not found.
+	// e.g. /ui/unknown-file -> /ui/index.html
+	// This will allow react router to handle the routing to the correct component file.
+	uiHTTPDir := uiHTTPDir{http.FS(uiFS)}
+
+	fileServer := http.StripPrefix("/ui", http.FileServer(uiHTTPDir))
 
 	serverUIHandler := func(w http.ResponseWriter) error {
 		// microcluster sets the Content-Type header to application/json by default. We need to remove it to serve the UI.
@@ -70,4 +80,18 @@ func serveUI(s *state.State, r *http.Request) response.Response {
 	}
 
 	return response.ManualResponse(serverUIHandler)
+}
+
+type uiHTTPDir struct {
+	http.FileSystem
+}
+
+// Open opens the HTTP server for the user interface files.
+func (fs uiHTTPDir) Open(name string) (http.File, error) {
+	fsFile, err := fs.FileSystem.Open(name)
+	if err != nil && os.IsNotExist(err) {
+		return fs.FileSystem.Open("index.html")
+	}
+
+	return fsFile, err
 }

--- a/internal/api/ui.go
+++ b/internal/api/ui.go
@@ -26,6 +26,7 @@ var uiServeRoutes = []string{
 	"ui",
 	"ui/assets/{asset}",
 	"ui/assets/img/{image}",
+	"ui/sites",
 }
 
 func generateUIEndpoints() []rest.Endpoint {


### PR DESCRIPTION
## Done
- Since the ui implements lazy loading, this means components will be their own static JS files in the `static` directory. When navigating to a specific ui path, a request is sent to the same backend server path e.g. `/ui/sites` for the component. Since this route is not a valid file path in the `static` directory, we need to open `index.html` instead. This will load the built `index.js` file which then will load the correct `[Component].js` file. This is fixed by setting up a `uiHTTPDir` struct that implements the `http.FileSystem` interface where we define a custom `Open` method that will open the `index.html` file if a file path is not found.
- Created a slice `uiServeRoutes` which is used to generate all the endpoints + handlers for the ui routes.
- Added `ui/sites` route

## Context
 - Microcluster currently does not expose the `mux` object on which we can use the `mux.PathPrefix` method to define generic path prefix matching. Each endpoint must be defined individually which is not ideal, but an upstream update for this may be a larger task than it seems since these endpoints will need to be defined at the top level of the server and that's a paradigm change. For now, we will need to add each frontend route to the `uiServeRoutes` slice which should solve the issue in #20.
 - The above challenge could be improved by some code generation magic. If we can somehow export all the routes into a json file that will live in the `static` directory, then we can read that list out in the go server and generate all the endpoints for those ui routes. At least we can have a single source of truth that way. I wonder if we can customise the vite build step to achieve that somehow?