### PR TITLE
fix: ui auth should redirect to login on auth errors 

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -126,7 +126,7 @@ jobs:
           lxd-site-mgr --state-dir ./state/dir1/ init "member1" 0.0.0.0:9001 --bootstrap
 
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps ${{ matrix.browser }}
+        run: cd ui && npx playwright install --with-deps ${{ matrix.browser }}
 
       - name: Run Playwright tests
         run: cd ui && npx playwright test --project ${{ matrix.browser }}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,16 +1,46 @@
-import { FC, lazy, Suspense } from "react";
-import { Navigate, Route, Routes } from "react-router-dom";
+import React, { FC, lazy, Suspense } from "react";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { fetchSites } from "api/sites";
+import NoMatch from "pages/NoMatch";
 
 const SiteList = lazy(() => import("pages/sites/SiteList"));
 const Login = lazy(() => import("pages/Login"));
 
 const App: FC = () => {
+  const { pathname } = useLocation();
+
+  const { error, isLoading } = useQuery({
+    queryKey: [queryKeys.sites],
+    queryFn: fetchSites,
+    retry: false,
+  });
+
+  const isAuthError = error?.message === "not authorized";
+  const isLoginPath = pathname === "/ui/login";
+
+  if (!isLoading && !isLoginPath && isAuthError) {
+    window.location.href = "/ui/login";
+    return null;
+  }
+
+  if (!isLoading && isLoginPath && !isAuthError) {
+    window.location.href = "/ui/sites";
+    return null;
+  }
+
   return (
     <Suspense fallback={<div>Loading</div>}>
       <Routes>
-        <Route path="/" element={<Navigate to="/ui" replace={true} />} />
-        <Route path="/ui" element={<Login />} />
+        <Route path="/" element={<Navigate to="/ui/sites" replace={true} />} />
+        <Route
+          path="/ui"
+          element={<Navigate to="/ui/sites" replace={true} />}
+        />
+        <Route path="/ui/login" element={<Login />} />
         <Route path="/ui/sites" element={<SiteList />} />
+        <Route path="*" element={<NoMatch />} />
       </Routes>
     </Suspense>
   );

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -1,13 +1,12 @@
 import { FC } from "react";
-import { Button, LoginPageLayout } from "@canonical/react-components";
-import { useNavigate } from "react-router-dom";
+import { Link, LoginPageLayout } from "@canonical/react-components";
 
 const Login: FC = () => {
-  const navigate = useNavigate();
-
   return (
     <LoginPageLayout title="Login to LXD site manager">
-      <Button onClick={() => navigate("/oidc/login")}>Login</Button>
+      <Link href="/oidc/login" className="p-button">
+        Login
+      </Link>
     </LoginPageLayout>
   );
 };

--- a/ui/src/pages/NoMatch.tsx
+++ b/ui/src/pages/NoMatch.tsx
@@ -1,0 +1,14 @@
+import { FC } from "react";
+import { Link, LoginPageLayout } from "@canonical/react-components";
+
+const NoMatch: FC = () => {
+  return (
+    <LoginPageLayout title="404 Page not found">
+      Sorry, we cannot find the page that you are looking for.
+      <br />
+      <Link href="/">Go to index page</Link>
+    </LoginPageLayout>
+  );
+};
+
+export default NoMatch;

--- a/ui/src/pages/sites/SiteList.tsx
+++ b/ui/src/pages/sites/SiteList.tsx
@@ -2,11 +2,9 @@ import { FC } from "react";
 import { queryKeys } from "util/queryKeys";
 import { fetchSites } from "api/sites";
 import { useQuery } from "@tanstack/react-query";
-import { Button, MainTable } from "@canonical/react-components";
-import { useNavigate } from "react-router-dom";
+import { Link, MainTable } from "@canonical/react-components";
 
 const SiteList: FC = () => {
-  const navigate = useNavigate();
   const { data: sites = [] } = useQuery({
     queryKey: [queryKeys.sites],
     queryFn: fetchSites,
@@ -32,7 +30,9 @@ const SiteList: FC = () => {
         })}
       />
 
-      <Button onClick={() => navigate("/oidc/logout")}>Logout</Button>
+      <Link href="/oidc/logout" className="p-button">
+        Logout
+      </Link>
     </div>
   );
 };


### PR DESCRIPTION
# Done
- move login page to dedicated route
- redirect to login page on auth errors
- redirect to site list after user authenticated.
- add a 404 page.