### PR TITLE
add DELETE endpoint for `/sites/:name` [WD-11657]

### DIFF
--- a/internal/api/sites.go
+++ b/internal/api/sites.go
@@ -23,8 +23,9 @@ var sitesCmd = rest.Endpoint{
 }
 
 var siteCmd = rest.Endpoint{
-	Path: "sites/{siteName}",
-	Get:  rest.EndpointAction{Handler: siteGet, AllowUntrusted: true},
+	Path:   "sites/{siteName}",
+	Get:    rest.EndpointAction{Handler: siteGet, AllowUntrusted: true},
+	Delete: rest.EndpointAction{Handler: siteDelete, AllowUntrusted: true},
 }
 
 func sitesGet(s *state.State, r *http.Request) response.Response {
@@ -65,6 +66,23 @@ func siteGet(s *state.State, r *http.Request) response.Response {
 	}
 
 	return response.SyncResponse(true, toSitesAPI(dbSiteMemberStatuses)[0])
+}
+
+func siteDelete(s *state.State, r *http.Request) response.Response {
+	siteName, err := url.PathUnescape(mux.Vars(r)["siteName"])
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	err = s.Database.Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return database.DeleteCoreSite(ctx, tx, siteName)
+	})
+
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.EmptySyncResponse
 }
 
 func toSitesAPI(dbEntries []database.MemberStatusWithSiteInfo) []types.Site {

--- a/ui/src/api/sites.ts
+++ b/ui/src/api/sites.ts
@@ -10,3 +10,14 @@ export const fetchSites = (): Promise<Site[]> => {
       .catch(reject);
   });
 };
+
+export const deleteSite = (siteName: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/sites/${siteName}`, {
+      method: "DELETE",
+    })
+      .then(handleResponse)
+      .then(() => resolve())
+      .catch(reject);
+  });
+};

--- a/ui/src/pages/sites/DeleteSiteButton.tsx
+++ b/ui/src/pages/sites/DeleteSiteButton.tsx
@@ -1,0 +1,40 @@
+import { ActionButton } from "@canonical/react-components";
+import { useQueryClient } from "@tanstack/react-query";
+import { deleteSite } from "api/sites";
+import { FC, useState } from "react";
+import { queryKeys } from "util/queryKeys";
+
+type Props = {
+  siteName: string;
+};
+
+const DeleteSiteButton: FC<Props> = ({ siteName }) => {
+  const queryClient = useQueryClient();
+  const [isLoading, setLoading] = useState(false);
+
+  const handleDeleteSite = async () => {
+    setLoading(true);
+
+    try {
+      await deleteSite(siteName);
+      await queryClient.invalidateQueries({
+        queryKey: [queryKeys.sites],
+      });
+      setLoading(false);
+    } catch (error) {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ActionButton
+      onClick={() => void handleDeleteSite()}
+      appearance="negative"
+      loading={isLoading}
+    >
+      Delete
+    </ActionButton>
+  );
+};
+
+export default DeleteSiteButton;

--- a/ui/src/pages/sites/SiteList.tsx
+++ b/ui/src/pages/sites/SiteList.tsx
@@ -3,6 +3,7 @@ import { queryKeys } from "util/queryKeys";
 import { fetchSites } from "api/sites";
 import { useQuery } from "@tanstack/react-query";
 import { Link, MainTable } from "@canonical/react-components";
+import DeleteSiteButton from "./DeleteSiteButton";
 
 const SiteList: FC = () => {
   const { data: sites = [] } = useQuery({
@@ -19,14 +20,18 @@ const SiteList: FC = () => {
           { content: "Status" },
           { content: "JoinedAt" },
           { content: "Instance Count" },
+          { content: "Actions" },
         ]}
-        rows={sites.map((site) => {
+        rows={(sites || []).map((site) => {
           return {
             columns: [
               { content: site.name },
               { content: site.status },
               { content: site.joined_at },
               { content: site.instance_count },
+              {
+                content: <DeleteSiteButton siteName={site.name} />,
+              },
             ],
           };
         })}


### PR DESCRIPTION
## Done
 - Added a DELETE endpoint for `1.0/sites/:name`
 - Added some buttons in the UI for testing the delete endpoint

## Context
 - With #24 merged, this has become quite easy since we have already implemented the db methods.