### PR TITLE
add site management listener `PATCH` and `GET` endpoints for `/1.0/configs` [WD-12693]

### DIFF
--- a/internal/api/configs.go
+++ b/internal/api/configs.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/canonical/lxd/lxd/db/query"
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/state"
+
+	"github.com/canonical/lxd-site-manager/internal/api/types"
+	"github.com/canonical/lxd-site-manager/internal/database"
+)
+
+var configsCmd = rest.Endpoint{
+	Path:  "config",
+	Patch: rest.EndpointAction{Handler: configsPatch, AllowUntrusted: true},
+	Get:   rest.EndpointAction{Handler: configsGet, AllowUntrusted: true},
+}
+
+// partially update manager configs, replace configs only if they exist in payload.
+func configsPatch(s *state.State, r *http.Request) response.Response {
+	var payload types.ManagerConfigs
+
+	err := json.NewDecoder(r.Body).Decode(&payload)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	if payload.Config == nil {
+		return response.BadRequest(fmt.Errorf("missing config key"))
+	}
+
+	err = types.ValidateConfigKeys(payload.Config)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	err = s.Database.Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		err := query.UpdateConfig(tx, "manager_configs", payload.Config)
+		return err
+	})
+
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.EmptySyncResponse
+}
+
+func configsGet(s *state.State, r *http.Request) response.Response {
+	var dbConfigs []database.ManagerConfig
+	err := s.Database.Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		var err error
+		dbConfigs, err = database.GetManagerConfig(ctx, tx)
+		return err
+	})
+
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.SyncResponse(true, toConfigsAPI(dbConfigs))
+}
+
+func toConfigsAPI(dbConfigs []database.ManagerConfig) types.ManagerConfigs {
+	configs := types.ManagerConfigs{
+		Config: map[string]string{},
+	}
+
+	for _, c := range dbConfigs {
+		configs.Config[c.Key] = c.Value
+	}
+
+	return configs
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -7,7 +7,8 @@ import (
 )
 
 var siteManagementListener = rest.Server{
-	CoreAPI: true,
+	CoreAPI:   true,
+	ServeUnix: true,
 	Resources: []rest.Resources{
 		{
 			PathPrefix: types.NoPrefix,
@@ -23,6 +24,7 @@ var siteManagementListener = rest.Server{
 			Endpoints: []rest.Endpoint{
 				siteCmd,
 				sitesCmd,
+				configsCmd,
 			},
 		},
 	},

--- a/internal/api/types/config.go
+++ b/internal/api/types/config.go
@@ -1,0 +1,30 @@
+package types
+
+import "fmt"
+
+// ManagerConfigs represents the site manager configs that are cluster wide.
+type ManagerConfigs struct {
+	Config map[string]string `json:"config"`
+}
+
+// ValidManagerConfigKeys returns a map of valid manager config keys.
+func ValidManagerConfigKeys() map[string]bool {
+	return map[string]bool{
+		"oidc.issuer":    true,
+		"oidc.client.id": true,
+		"oidc.audience":  true,
+		"global.address": true,
+	}
+}
+
+// ValidateConfigKeys validates the given config keys that they exist in the map of valid config keys for site manager.
+func ValidateConfigKeys(config map[string]string) error {
+	for k := range config {
+		_, ok := ValidManagerConfigKeys()[k]
+		if !ok {
+			return fmt.Errorf("invalid config key: %s", k)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Done
- [x]  ~~Add `PUT /1.0/configs` which will replace all existing configs with payload~~
- [X]  Add `PATCH /1.0/configs` which will upsert config key/values
- [X]  Add `GET /1.0/configs` return all site manager configs