### PR TITLE
add member specific configs endpoints [WD-12695]

### DIFF
--- a/internal/api/member_configs.go
+++ b/internal/api/member_configs.go
@@ -1,0 +1,179 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/rest"
+	microTypes "github.com/canonical/microcluster/rest/types"
+	"github.com/canonical/microcluster/state"
+	"github.com/gorilla/mux"
+
+	"github.com/canonical/lxd-site-manager/internal/api/types"
+	"github.com/canonical/lxd-site-manager/internal/database"
+)
+
+var memberConfigCmd = rest.Endpoint{
+	Path:  "member/{name}/config",
+	Patch: rest.EndpointAction{Handler: memberConfigPatch, AllowUntrusted: true},
+	Get:   rest.EndpointAction{Handler: memberConfigGet, AllowUntrusted: true},
+}
+
+var memberConfigsCmd = rest.Endpoint{
+	Path: "member/config",
+	Get:  rest.EndpointAction{Handler: memberConfigsGet, AllowUntrusted: true},
+}
+
+// update existing member configs.
+func memberConfigPatch(s *state.State, r *http.Request) response.Response {
+	memberName, err := url.PathUnescape(mux.Vars(r)["name"])
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	var payload types.MemberConfigPatch
+	err = json.NewDecoder(r.Body).Decode(&payload)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	// validations
+	if payload.HTTPSAddress == "" && payload.ExternalAddress == "" {
+		return response.BadRequest(fmt.Errorf("no fields provided to update"))
+	}
+
+	if payload.HTTPSAddress != "" {
+		_, err = microTypes.ParseAddrPort(payload.HTTPSAddress)
+		if err != nil {
+			return response.BadRequest(fmt.Errorf("invalid https_address for member %q: %w", memberName, err))
+		}
+	}
+
+	if payload.ExternalAddress != "" {
+		_, err = microTypes.ParseAddrPort(payload.ExternalAddress)
+		if err != nil {
+			return response.BadRequest(fmt.Errorf("invalid external_address for member %q: %w", memberName, err))
+		}
+	}
+
+	err = s.Database.Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		// get existing member config entry and use it as a base
+		filter := database.ManagerMemberConfigFilter{
+			Target: &memberName,
+		}
+
+		dbConfigs, err := database.GetManagerMemberConfig(ctx, tx, filter)
+		if err != nil {
+			return err
+		}
+
+		memberConfigExist := len(dbConfigs) > 0
+
+		// create new member config
+		if !memberConfigExist {
+			if payload.HTTPSAddress == "" {
+				return fmt.Errorf("https_address is required")
+			}
+
+			_, err := database.CreateManagerMemberConfig(ctx, tx, database.ManagerMemberConfig{
+				Target:          memberName,
+				HTTPSAddress:    payload.HTTPSAddress,
+				ExternalAddress: payload.ExternalAddress,
+			})
+
+			return err
+		}
+
+		// update existing member config
+		// if no value is provided, keep the existing one
+		HTTPSAddress := dbConfigs[0].HTTPSAddress
+		externalAddress := dbConfigs[0].ExternalAddress
+
+		if payload.HTTPSAddress != "" {
+			HTTPSAddress = payload.HTTPSAddress
+		}
+
+		if payload.ExternalAddress != "" {
+			externalAddress = payload.ExternalAddress
+		}
+
+		return database.UpdateManagerMemberConfig(ctx, tx, memberName, database.ManagerMemberConfig{
+			Target:          memberName,
+			HTTPSAddress:    HTTPSAddress,
+			ExternalAddress: externalAddress,
+		})
+	})
+
+	if err != nil {
+		if err.Error() == "https_address is required" {
+			return response.BadRequest(err)
+		}
+
+		return response.SmartError(err)
+	}
+
+	return response.EmptySyncResponse
+}
+
+func memberConfigGet(s *state.State, r *http.Request) response.Response {
+	memberName, err := url.PathUnescape(mux.Vars(r)["name"])
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	var dbConfigs []database.ManagerMemberConfig
+	err = s.Database.Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		var err error
+		filter := database.ManagerMemberConfigFilter{
+			Target: &memberName,
+		}
+
+		dbConfigs, err = database.GetManagerMemberConfig(ctx, tx, filter)
+		return err
+	})
+
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if len(dbConfigs) == 0 {
+		return response.NotFound(fmt.Errorf("Member not found"))
+	}
+
+	return response.SyncResponse(true, toMemberConfigsAPI(dbConfigs)[0])
+}
+
+func memberConfigsGet(s *state.State, r *http.Request) response.Response {
+	var dbConfigs []database.ManagerMemberConfig
+	err := s.Database.Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		var err error
+		dbConfigs, err = database.GetManagerMemberConfig(ctx, tx)
+		return err
+	})
+
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.SyncResponse(true, toMemberConfigsAPI(dbConfigs))
+}
+
+func toMemberConfigsAPI(dbConfigs []database.ManagerMemberConfig) []types.MemberConfig {
+	var memberConfigs []types.MemberConfig
+	for _, c := range dbConfigs {
+		memberConfigs = append(memberConfigs, types.MemberConfig{
+			Target: c.Target,
+			MemberConfigPatch: types.MemberConfigPatch{
+				HTTPSAddress:    c.HTTPSAddress,
+				ExternalAddress: c.ExternalAddress,
+			},
+		})
+	}
+
+	return memberConfigs
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -25,6 +25,8 @@ var siteManagementListener = rest.Server{
 				siteCmd,
 				sitesCmd,
 				configsCmd,
+				memberConfigCmd,
+				memberConfigsCmd,
 			},
 		},
 	},

--- a/internal/api/types/member_configs.go
+++ b/internal/api/types/member_configs.go
@@ -1,0 +1,13 @@
+package types
+
+// MemberConfigPatch represents the payload required to update configs for a single site manager member.
+type MemberConfigPatch struct {
+	HTTPSAddress    string `json:"https_address,omitempty"`
+	ExternalAddress string `json:"external_address,omitempty"`
+}
+
+// MemberConfig represents config data for a single site manager member, which includes the member name.
+type MemberConfig struct {
+	Target string `json:"target"`
+	MemberConfigPatch
+}

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -73,8 +73,9 @@ func schemaUpdate1(ctx context.Context, tx *sql.Tx) error {
             id                      INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
             target                  TEXT NOT NULL,
             https_address           TEXT NOT NULL,
-            external_address        TEXT,
-            FOREIGN KEY (target) REFERENCES internal_cluster_members (name) ON DELETE CASCADE
+            external_address        TEXT NOT NULL default '',
+            FOREIGN KEY (target) REFERENCES internal_cluster_members (name) ON DELETE CASCADE,
+            UNIQUE (target)
         );
     `
 


### PR DESCRIPTION
## Done
- [x] add `Get` and `Patch` endpoints for `/1.0/member/:name/config`.
- [x] added a `GET /1.0/member/config` endpoint to get all member configs
- [ ] restart network listener if `https_address` is updated for a member (this is not possible to do at the moment in microcluster)

## Context
 - The [network listener spec](https://docs.google.com/document/d/1juo7BfQ8jmaUnGbMpm5T2_e0Dn6jhOmCi1lOEu_Cp2w/edit) for microcluster indicates network listener addresses will be stored in the state directory on each member and not in dqlite. This means first, we do not need to have `https_address` as a column in the `manager_configs` table and second, to read/modify `https_address` we will need to interact with the state directory instead of dqlite.