### PR TITLE
fix: fix the vite dev server not loading assets

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       "/ui/assets": {
-        target: "http://0.0.0.0:8414/",
+        target: "https://0.0.0.0:8414/",
         rewrite: (path) => path.replace(/^\/ui/, ""),
         secure: false,
       },


### PR DESCRIPTION
## Done
WIth SSL enabled for haproxy now, we need to configure the vite dev server to have https proxy target for ui assets. This PR fixes that. The fix is already in #36 but let's get this merged so long.