### PR TITLE
cli for generating external site join token [WD-13155]

### DIFF
--- a/cmd/lxd-site-mgr/external_site_join_tokens.go
+++ b/cmd/lxd-site-mgr/external_site_join_tokens.go
@@ -30,6 +30,9 @@ func (c *cmdExternalSiteJoinToken) command() *cobra.Command {
 	var cmdShow = cmdExternalSiteJoinTokenShow{common: c.common}
 	cmd.AddCommand(cmdShow.command())
 
+	var cmdRevoke = cmdExternalSiteJoinTokenRevoke{common: c.common}
+	cmd.AddCommand(cmdRevoke.command())
+
 	return cmd
 }
 
@@ -163,4 +166,46 @@ func (c *cmdExternalSiteJoinTokenShow) run(cmd *cobra.Command, args []string) er
 
 	sort.Sort(lxdCmd.SortColumnsNaturally(rows))
 	return lxdCmd.RenderTable(lxdCmd.TableFormatTable, headers, rows, tokens)
+}
+
+type cmdExternalSiteJoinTokenRevoke struct {
+	common *CmdControl
+}
+
+func (c *cmdExternalSiteJoinTokenRevoke) command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "revoke <site_name>",
+		Short: "Revoke the external site join token with the given LXD site name.",
+		Example: `
+			lxd-site-mgr external-site-join-token revoke <site_name>
+			Will render the specific external site join token invalid.
+		`,
+		RunE: c.run,
+	}
+
+	return cmd
+}
+
+func (c *cmdExternalSiteJoinTokenRevoke) run(cmd *cobra.Command, args []string) error {
+	m, err := microcluster.App(microcluster.Args{
+		StateDir: c.common.FlagStateDir,
+		Verbose:  c.common.FlagLogVerbose,
+		Debug:    c.common.FlagLogDebug,
+		Version:  version.Version(),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	if len(args) < 1 {
+		return cmd.Help()
+	}
+
+	return client.ExternalSiteJoinTokenDeleteCmd(cmd.Context(), cli, args[0])
 }

--- a/cmd/lxd-site-mgr/external_site_join_tokens.go
+++ b/cmd/lxd-site-mgr/external_site_join_tokens.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"sort"
 	"time"
 
+	lxdCmd "github.com/canonical/lxd/shared/cmd"
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/spf13/cobra"
 
@@ -24,6 +26,9 @@ func (c *cmdExternalSiteJoinToken) command() *cobra.Command {
 
 	var cmdAdd = cmdExternalSiteJoinTokenAdd{common: c.common}
 	cmd.AddCommand(cmdAdd.command())
+
+	var cmdShow = cmdExternalSiteJoinTokenShow{common: c.common}
+	cmd.AddCommand(cmdShow.command())
 
 	return cmd
 }
@@ -95,4 +100,67 @@ func (c *cmdExternalSiteJoinTokenAdd) run(cmd *cobra.Command, args []string) err
 	cmd.Println("The token can not be retrieved at a later stage, please save it now.")
 	cmd.Println(token)
 	return nil
+}
+
+type cmdExternalSiteJoinTokenShow struct {
+	common *CmdControl
+}
+
+func (c *cmdExternalSiteJoinTokenShow) command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "List all external join tokens for LXD sites.",
+		Example: `
+			lxd-site-mgr external-site-join-token show
+			Will list all external join tokens.
+		`,
+		RunE: c.run,
+	}
+
+	return cmd
+}
+
+func (c *cmdExternalSiteJoinTokenShow) run(cmd *cobra.Command, args []string) error {
+	m, err := microcluster.App(microcluster.Args{
+		StateDir: c.common.FlagStateDir,
+		Verbose:  c.common.FlagLogVerbose,
+		Debug:    c.common.FlagLogDebug,
+		Version:  version.Version(),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	if len(args) > 0 {
+		return cmd.Help()
+	}
+
+	tokens, err := client.ExternalSiteJoinTokenGetCmd(cmd.Context(), cli)
+	if err != nil {
+		return err
+	}
+
+	headers := []string{
+		"SITE_NAME",
+		"EXPIRY",
+		"CREATED_AT",
+	}
+
+	var rows [][]string
+	for _, token := range tokens {
+		rows = append(rows, []string{
+			token.SiteName,
+			token.Expiry.String(),
+			token.CreateAt.String(),
+		})
+	}
+
+	sort.Sort(lxdCmd.SortColumnsNaturally(rows))
+	return lxdCmd.RenderTable(lxdCmd.TableFormatTable, headers, rows, tokens)
 }

--- a/cmd/lxd-site-mgr/external_site_join_tokens.go
+++ b/cmd/lxd-site-mgr/external_site_join_tokens.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"time"
+
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/spf13/cobra"
+
+	"github.com/canonical/lxd-site-manager/internal/api/types"
+	"github.com/canonical/lxd-site-manager/internal/client"
+	"github.com/canonical/lxd-site-manager/version"
+)
+
+type cmdExternalSiteJoinToken struct {
+	common *CmdControl
+}
+
+func (c *cmdExternalSiteJoinToken) command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "external-site-join-token",
+		Short: "manage external join tokens for LXD sites.",
+		RunE:  c.run,
+	}
+
+	var cmdAdd = cmdExternalSiteJoinTokenAdd{common: c.common}
+	cmd.AddCommand(cmdAdd.command())
+
+	return cmd
+}
+
+func (c *cmdExternalSiteJoinToken) run(cmd *cobra.Command, args []string) error {
+	return cmd.Help()
+}
+
+type cmdExternalSiteJoinTokenAdd struct {
+	common *CmdControl
+
+	flagExpiry time.Duration
+}
+
+func (c *cmdExternalSiteJoinTokenAdd) command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add <site_name>",
+		Short: "Add a new external join token for a LXD site.",
+		Example: `
+			lxd-site-mgr external-site-join-token add <site_name>
+			Will created an external site join token for a LXD site.
+		`,
+		RunE: c.run,
+	}
+
+	cmd.Flags().DurationVar(&c.flagExpiry, "expiry", 0, "Specify the duration (i.e. 5m or 48h) for the token to be valid")
+
+	return cmd
+}
+
+func (c *cmdExternalSiteJoinTokenAdd) run(cmd *cobra.Command, args []string) error {
+	m, err := microcluster.App(microcluster.Args{
+		StateDir: c.common.FlagStateDir,
+		Verbose:  c.common.FlagLogVerbose,
+		Debug:    c.common.FlagLogDebug,
+		Version:  version.Version(),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	if len(args) < 1 {
+		return cmd.Help()
+	}
+
+	// convert expiry flag from duration to time stamp
+	expiry := time.Time{}
+	if c.flagExpiry != 0 {
+		expiry = time.Now().Add(c.flagExpiry)
+	}
+
+	siteName := args[0]
+	payload := types.ExternalSiteTokenPost{
+		SiteName: siteName,
+		Expiry:   expiry,
+	}
+
+	token, err := client.ExternalSiteJoinTokenPostCmd(cmd.Context(), cli, &payload)
+	if err != nil {
+		return err
+	}
+
+	cmd.Println("The token can not be retrieved at a later stage, please save it now.")
+	cmd.Println(token)
+	return nil
+}

--- a/cmd/lxd-site-mgr/main.go
+++ b/cmd/lxd-site-mgr/main.go
@@ -65,6 +65,9 @@ func main() {
 	var cmdConfig = cmdConfig{common: &commonCmd}
 	app.AddCommand(cmdConfig.command())
 
+	var cmdExternalSiteJoinToken = cmdExternalSiteJoinToken{common: &commonCmd}
+	app.AddCommand(cmdExternalSiteJoinToken.command())
+
 	app.InitDefaultHelpCmd()
 
 	err := app.Execute()

--- a/internal/api/external_site_join_tokens.go
+++ b/internal/api/external_site_join_tokens.go
@@ -51,8 +51,9 @@ func tokenPost(s microState.State, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
+	// default expiry to 1 day if not set
 	if payload.Expiry == (time.Time{}) {
-		return response.BadRequest(fmt.Errorf("token must have an expiry date"))
+		payload.Expiry = time.Now().Add(time.Hour * 24)
 	}
 
 	if payload.Expiry.Before(time.Now()) {

--- a/internal/client/external_site_join_tokens.go
+++ b/internal/client/external_site_join_tokens.go
@@ -42,3 +42,18 @@ func ExternalSiteJoinTokenGetCmd(ctx context.Context, c *client.Client) ([]types
 
 	return tokens, nil
 }
+
+// ExternalSiteJoinTokenDeleteCmd sends a DELETE request to /1.0/external-site-join-token/{siteName}.
+func ExternalSiteJoinTokenDeleteCmd(ctx context.Context, c *client.Client, siteName string) error {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	url := api.NewURL().Path("external-site-join-token", siteName)
+	err := c.Query(queryCtx, "DELETE", types.APIVersionPrefix, url, nil, nil)
+	if err != nil {
+		clientURL := c.URL()
+		return fmt.Errorf("Failed performing action on %q: %w", clientURL.String(), err)
+	}
+
+	return nil
+}

--- a/internal/client/external_site_join_tokens.go
+++ b/internal/client/external_site_join_tokens.go
@@ -1,0 +1,28 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/microcluster/client"
+
+	"github.com/canonical/lxd-site-manager/internal/api/types"
+)
+
+// ExternalSiteJoinTokenPostCmd sends a POST request to /1.0/external-site-join-token.
+func ExternalSiteJoinTokenPostCmd(ctx context.Context, c *client.Client, payload *types.ExternalSiteTokenPost) (token string, err error) {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	tokenResponse := &types.ExternalSiteTokenPostResponse{}
+	url := api.NewURL().Path("external-site-join-token")
+	err = c.Query(queryCtx, "POST", types.APIVersionPrefix, url, payload, tokenResponse)
+	if err != nil {
+		clientURL := c.URL()
+		return "", fmt.Errorf("Failed performing action on %q: %w", clientURL.String(), err)
+	}
+
+	return tokenResponse.Token, nil
+}

--- a/internal/client/external_site_join_tokens.go
+++ b/internal/client/external_site_join_tokens.go
@@ -26,3 +26,19 @@ func ExternalSiteJoinTokenPostCmd(ctx context.Context, c *client.Client, payload
 
 	return tokenResponse.Token, nil
 }
+
+// ExternalSiteJoinTokenGetCmd sends a GET request to /1.0/external-site-join-token.
+func ExternalSiteJoinTokenGetCmd(ctx context.Context, c *client.Client) ([]types.ExternalSiteToken, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	tokens := []types.ExternalSiteToken{}
+	url := api.NewURL().Path("external-site-join-token")
+	err := c.Query(queryCtx, "GET", types.APIVersionPrefix, url, nil, &tokens)
+	if err != nil {
+		clientURL := c.URL()
+		return nil, fmt.Errorf("Failed performing action on %q: %w", clientURL.String(), err)
+	}
+
+	return tokens, nil
+}

--- a/scripts/generate_site_join_token.sh
+++ b/scripts/generate_site_join_token.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -e
-# Execute the curl command with the provided values
-curl --insecure -H 'Content-Type: application/json' -d '{
-  "expiry": "2025-01-01T00:00:00Z",
-  "site_name": "real_site_1"
-}' -X POST https://0.0.0.0:9001/1.0/external-site-join-token
+
+# if flag --local exists then use go run to run site-mgr
+if [ "$1" == "--local" ]; then
+    COMMAND="go run ./cmd/lxd-site-mgr"
+else
+    COMMAND="./lxd-site-mgr"
+fi
+
+$COMMAND --state-dir ./state/dir1 external-site-join-token add site1 --expiry 24h


### PR DESCRIPTION
## Done
 - added CLI for generating external site join token

## QA
 - try `go run ./cmd/lxd-site-mgr --state-dir state/dir1 external-site-join-tokens add <site_name> [--expiry=duration]`
 - try `go run ./cmd/lxd-site-mgr --state-dir state/dir1 external-site-join-tokens show`
 - try `go run ./cmd/lxd-site-mgr --state-dir state/dir1 external-site-join-tokens revoke <site_name>`