### PR TITLE
feat: [WD-13154] add Pending and Token tabs to the Clusters Page.

### DIFF
--- a/internal/api/ui.go
+++ b/internal/api/ui.go
@@ -26,8 +26,10 @@ var uiServeRoutes = []string{
 	"ui",
 	"ui/assets/{asset}",
 	"ui/assets/img/{image}",
-	"ui/sites",
 	"ui/login",
+	"ui/sites",
+	"ui/sites/pending",
+	"ui/sites/tokens",
 	"ui/settings",
 }
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     "hooks-remove": "husky uninstall",
     "start": "./entrypoint 0.0.0.0:${PORT}",
     "backend-run": "cd .. && make && go run ./cmd/lxd-site-mgrd --state-dir ./state/dir1/",
-    "backend-init": "cd .. &&  go run ./cmd/lxd-site-mgr --state-dir ./state/dir1/ waitready && go run ./cmd/lxd-site-mgr --state-dir ./state/dir1/ init \"member1\" 0.0.0.0:9001 --bootstrap --control-address 0.0.0.0:9010 && scripts/generate_sites.sh --local && scripts/generate_configs.sh --local",
+    "backend-init": "cd .. &&  go run ./cmd/lxd-site-mgr --state-dir ./state/dir1/ waitready && go run ./cmd/lxd-site-mgr --state-dir ./state/dir1/ init \"member1\" 0.0.0.0:9001 --bootstrap --control-address 0.0.0.0:9010 && scripts/generate_sites.sh --local && scripts/generate_configs.sh --local && scripts/generate_site_join_token.sh --local",
     "test-e2e": "npx playwright test",
     "test-e2e-update": "npx playwright test --update-snapshots"
   },

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -41,6 +41,7 @@ const App: FC = () => {
         />
         <Route path="/ui/login" element={<Login />} />
         <Route path="/ui/sites" element={<ClusterList />} />
+        <Route path="/ui/sites/:activeTab" element={<ClusterList />} />
         <Route path="/ui/settings" element={<Settings />} />
         <Route path="*" element={<NoMatch />} />
       </Routes>

--- a/ui/src/api/clusters.ts
+++ b/ui/src/api/clusters.ts
@@ -21,3 +21,13 @@ export const deleteCluster = (siteName: string): Promise<void> => {
       .catch(reject);
   });
 };
+export const approveCluster = (siteName: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/sites/${siteName}/approve`, {
+      method: "POST",
+    })
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};

--- a/ui/src/api/tokens.ts
+++ b/ui/src/api/tokens.ts
@@ -1,0 +1,12 @@
+import { LxdApiResponse } from "types/apiResponse";
+import { Token } from "types/token";
+import { handleResponse } from "util/helpers";
+
+export const fetchTokens = (): Promise<Token[]> => {
+  return new Promise((resolve, reject) => {
+    fetch("/1.0/external-site-join-token")
+      .then(handleResponse)
+      .then((data: LxdApiResponse<Token[]>) => resolve(data.metadata ?? []))
+      .catch(reject);
+  });
+};

--- a/ui/src/components/TabLinks.tsx
+++ b/ui/src/components/TabLinks.tsx
@@ -1,0 +1,47 @@
+import { FC } from "react";
+import { Tabs } from "@canonical/react-components";
+import { useNotify } from "@canonical/react-components";
+import { useNavigate } from "react-router-dom";
+import { TabLink } from "@canonical/react-components/dist/components/Tabs/Tabs";
+
+interface Props {
+  tabs: (string | TabLink)[];
+  activeTab?: string;
+  tabUrl: string;
+}
+
+const TabLinks: FC<Props> = ({ tabs, activeTab, tabUrl }) => {
+  const notify = useNotify();
+  const navigate = useNavigate();
+
+  const slugify = (name: string): string => {
+    return name.replace(" ", "-").toLowerCase();
+  };
+
+  return (
+    <Tabs
+      links={tabs.map((tab) => {
+        if (typeof tab !== "string") {
+          return tab;
+        }
+
+        const tabPath = slugify(tab);
+        const href = tab === tabs[0] ? tabUrl : `${tabUrl}/${tabPath}`;
+
+        return {
+          label: tab,
+          id: tabPath,
+          active: tabPath === activeTab || (tab === tabs[0] && !activeTab),
+          onClick: (e) => {
+            e.preventDefault();
+            notify.clear();
+            navigate(href);
+          },
+          href,
+        };
+      })}
+    />
+  );
+};
+
+export default TabLinks;

--- a/ui/src/pages/clusters/AddClusterButton.tsx
+++ b/ui/src/pages/clusters/AddClusterButton.tsx
@@ -1,0 +1,20 @@
+import { ActionButton } from "@canonical/react-components";
+import { FC } from "react";
+import { useNavigate } from "react-router-dom";
+
+const AddClusterButton: FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <ActionButton
+      onClick={() => {
+        navigate("/");
+      }}
+      appearance="positive"
+    >
+      Add New Cluster
+    </ActionButton>
+  );
+};
+
+export default AddClusterButton;

--- a/ui/src/pages/clusters/ApproveClusterButton.tsx
+++ b/ui/src/pages/clusters/ApproveClusterButton.tsx
@@ -1,0 +1,40 @@
+import { ActionButton } from "@canonical/react-components";
+import { useQueryClient } from "@tanstack/react-query";
+import { approveCluster } from "api/clusters";
+import { FC, useState } from "react";
+import { queryKeys } from "util/queryKeys";
+
+type Props = {
+  clusterName: string;
+};
+
+const ApproveClusterButton: FC<Props> = ({ clusterName }) => {
+  const queryClient = useQueryClient();
+  const [isLoading, setLoading] = useState(false);
+
+  const handleApproveCluster = async () => {
+    setLoading(true);
+
+    try {
+      await approveCluster(clusterName);
+      await queryClient.invalidateQueries({
+        queryKey: [queryKeys.clusters],
+      });
+      setLoading(false);
+    } catch (error) {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ActionButton
+      onClick={() => void handleApproveCluster()}
+      appearance="positive"
+      loading={isLoading}
+    >
+      Approve
+    </ActionButton>
+  );
+};
+
+export default ApproveClusterButton;

--- a/ui/src/pages/clusters/ClusterList.tsx
+++ b/ui/src/pages/clusters/ClusterList.tsx
@@ -1,103 +1,28 @@
 import { FC } from "react";
-import { queryKeys } from "util/queryKeys";
-import { fetchClusters } from "api/clusters";
-import { useQuery } from "@tanstack/react-query";
-import { MainTable, Row, TablePagination } from "@canonical/react-components";
-import Loader from "components/Loader";
+import { Row } from "@canonical/react-components";
 import BaseLayout from "components/BaseLayout";
-import { Link } from "react-router-dom";
-import { ClusterInstances } from "components/meters/ClusterInstances";
-import { ClusterCpu } from "components/meters/ClusterCpu";
-import { ClusterMemory } from "components/meters/ClusterMemory";
-import { ClusterDisk } from "components/meters/ClusterDisk";
-import { ClusterNodes } from "components/meters/ClusterNodes";
-import ClusterHeartbeat from "components/ClusterHeartbeat";
+import { useParams } from "react-router-dom";
+import TabLinks from "components/TabLinks";
+import ClusterListTokens from "./ClusterListTokens";
+import ClusterListActive from "./ClusterListActive";
+import ClusterListPending from "./ClusterListPending";
+import AddClusterButton from "./AddClusterButton";
 
 const ClusterList: FC = () => {
-  const { data: clusters = [], isLoading } = useQuery({
-    queryKey: [queryKeys.clusters],
-    queryFn: fetchClusters,
-  });
+  const { activeTab } = useParams<{
+    activeTab?: string;
+  }>();
 
-  const tableRows = clusters.map((cluster) => {
-    return {
-      columns: [
-        {
-          content: (
-            <Link to={`/ui/cluster/${cluster.name}`}>{cluster.name}</Link>
-          ),
-        },
-        { content: <ClusterHeartbeat cluster={cluster} /> },
-        {
-          content: <ClusterNodes cluster={cluster} />,
-        },
-        {
-          content: <ClusterInstances cluster={cluster} />,
-        },
-        {
-          content: <ClusterCpu cluster={cluster} />,
-        },
-        {
-          content: <ClusterMemory cluster={cluster} />,
-        },
-        {
-          content: <ClusterDisk cluster={cluster} />,
-        },
-      ],
-    };
-  });
-
-  const tableHeaders = [
-    {
-      content: "Cluster Name",
-    },
-    {
-      content: "Last Heartbeat",
-    },
-    {
-      content: "Nodes",
-    },
-    {
-      content: "Instances",
-    },
-    {
-      content: "CPU",
-    },
-    {
-      content: "Memory",
-    },
-    {
-      content: "Disk",
-    },
-  ];
+  const tabs: string[] = ["Active", "Pending", "Tokens"];
 
   return (
-    <BaseLayout title={"Clusters"}>
+    <BaseLayout title={"Clusters"} controls={<AddClusterButton />}>
       <Row>
+        <TabLinks tabs={tabs} activeTab={activeTab} tabUrl="/ui/sites" />
         <div>
-          <div className="clusterlist-table-container">
-            <TablePagination
-              data={tableRows}
-              id="pagination"
-              itemName="cluster"
-              className="u-no-margin--top"
-              aria-label="Table pagination control"
-            >
-              <MainTable
-                className={"clusterlist-table"}
-                responsive={true}
-                emptyStateMsg={
-                  isLoading ? (
-                    <Loader text="Loading clusters..." />
-                  ) : (
-                    <>No instance found matching this search</>
-                  )
-                }
-                headers={tableHeaders}
-                rows={tableRows}
-              />
-            </TablePagination>
-          </div>
+          {!activeTab && <ClusterListActive />}
+          {activeTab === "pending" && <ClusterListPending />}
+          {activeTab === "tokens" && <ClusterListTokens />}
         </div>
       </Row>
     </BaseLayout>

--- a/ui/src/pages/clusters/ClusterListActive.tsx
+++ b/ui/src/pages/clusters/ClusterListActive.tsx
@@ -1,0 +1,108 @@
+import { FC } from "react";
+import { fetchClusters } from "api/clusters";
+import { useQuery } from "@tanstack/react-query";
+import { MainTable, TablePagination } from "@canonical/react-components";
+import Loader from "components/Loader";
+import { Link } from "react-router-dom";
+import { ClusterInstances } from "components/meters/ClusterInstances";
+import { ClusterCpu } from "components/meters/ClusterCpu";
+import { ClusterMemory } from "components/meters/ClusterMemory";
+import { ClusterDisk } from "components/meters/ClusterDisk";
+import { ClusterNodes } from "components/meters/ClusterNodes";
+import ClusterHeartbeat from "components/ClusterHeartbeat";
+import { queryKeys } from "util/queryKeys";
+
+const ClusterListActive: FC = () => {
+  const { data: clusters = [], isLoading } = useQuery({
+    queryKey: [queryKeys.clusters],
+    queryFn: fetchClusters,
+  });
+
+  const filteredClusters = clusters.filter(
+    (cluster) => cluster.status == "ACTIVE",
+  );
+
+  const tableHeaders = [
+    {
+      content: "Cluster Name",
+    },
+    {
+      content: "Last Heartbeat",
+    },
+    {
+      content: "Nodes",
+    },
+    {
+      content: "Instances",
+    },
+    {
+      content: "CPU",
+    },
+    {
+      content: "Memory",
+    },
+    {
+      content: "Disk",
+    },
+  ];
+
+  const tableRows = filteredClusters.map((cluster) => {
+    return {
+      columns: [
+        {
+          content: (
+            <Link to={`/ui/cluster/${cluster.name}`}>{cluster.name}</Link>
+          ),
+        },
+        { content: <ClusterHeartbeat cluster={cluster} /> },
+        {
+          content: <ClusterNodes cluster={cluster} />,
+        },
+        {
+          content: <ClusterInstances cluster={cluster} />,
+        },
+        {
+          content: <ClusterCpu cluster={cluster} />,
+        },
+        {
+          content: <ClusterMemory cluster={cluster} />,
+        },
+        {
+          content: <ClusterDisk cluster={cluster} />,
+        },
+      ],
+    };
+  });
+
+  return (
+    <div
+      role="tabpanel"
+      aria-labelledby="Active"
+      className="clusterlist-table-container"
+    >
+      <TablePagination
+        data={tableRows}
+        id="pagination"
+        itemName="cluster"
+        className="u-no-margin--top"
+        aria-label="Table pagination control"
+      >
+        <MainTable
+          className={"clusterlist-table"}
+          responsive={true}
+          emptyStateMsg={
+            isLoading ? (
+              <Loader text="Loading Clusters..." />
+            ) : (
+              <>No clusters found matching this search.</>
+            )
+          }
+          headers={tableHeaders}
+          rows={tableRows}
+        />
+      </TablePagination>
+    </div>
+  );
+};
+
+export default ClusterListActive;

--- a/ui/src/pages/clusters/ClusterListPending.tsx
+++ b/ui/src/pages/clusters/ClusterListPending.tsx
@@ -1,0 +1,77 @@
+import { FC } from "react";
+import { fetchClusters } from "api/clusters";
+import { useQuery } from "@tanstack/react-query";
+import { MainTable, TablePagination } from "@canonical/react-components";
+import Loader from "components/Loader";
+import { queryKeys } from "util/queryKeys";
+import PendingClusterActions from "./PendingClusterActions";
+import { isoTimeToString } from "util/helpers";
+
+const ClusterListPending: FC = () => {
+  const { data: clusters = [], isLoading } = useQuery({
+    queryKey: [queryKeys.clusters],
+    queryFn: fetchClusters,
+  });
+
+  const filteredClusters = clusters.filter(
+    (cluster) => cluster.status == "PENDING_APPROVAL",
+  );
+
+  const tableHeaders = [
+    {
+      content: "Cluster Name",
+    },
+    {
+      content: "Join date",
+    },
+    {
+      content: "Actions",
+    },
+  ];
+
+  const tableRows = filteredClusters.map((cluster) => {
+    return {
+      columns: [
+        {
+          content: `${cluster.name}`,
+        },
+        { content: `${isoTimeToString(cluster.joined_at)}` },
+        {
+          content: <PendingClusterActions cluster={cluster} />,
+        },
+      ],
+    };
+  });
+
+  return (
+    <div
+      role="tabpanel"
+      aria-labelledby="Pending"
+      className="clusterlist-table-container"
+    >
+      <TablePagination
+        data={tableRows}
+        id="pagination"
+        itemName="cluster"
+        className="u-no-margin--top"
+        aria-label="Table pagination control"
+      >
+        <MainTable
+          className={"clusterlist-table"}
+          responsive={true}
+          emptyStateMsg={
+            isLoading ? (
+              <Loader text="Loading Clusters..." />
+            ) : (
+              <>No pending clusters.</>
+            )
+          }
+          headers={tableHeaders}
+          rows={tableRows}
+        />
+      </TablePagination>
+    </div>
+  );
+};
+
+export default ClusterListPending;

--- a/ui/src/pages/clusters/ClusterListTokens.tsx
+++ b/ui/src/pages/clusters/ClusterListTokens.tsx
@@ -1,0 +1,74 @@
+import { TablePagination, MainTable } from "@canonical/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { fetchTokens } from "api/tokens";
+import Loader from "components/Loader";
+import { FC } from "react";
+import { isoTimeToString } from "util/helpers";
+import { queryKeys } from "util/queryKeys";
+
+const ClusterListTokens: FC = () => {
+  const { data: tokens = [], isLoading } = useQuery({
+    queryKey: [queryKeys.tokens],
+    queryFn: fetchTokens,
+  });
+
+  const tableHeaders = [
+    {
+      content: "Site name",
+    },
+    {
+      content: "Expiry",
+    },
+    {
+      content: "Created at",
+    },
+  ];
+
+  const tableRows = tokens.map((token) => {
+    return {
+      columns: [
+        {
+          content: `${token.site_name}`,
+        },
+        {
+          content: `${isoTimeToString(token.expiry)}`,
+        },
+        {
+          content: `${isoTimeToString(token.created_at)}`,
+        },
+      ],
+    };
+  });
+
+  return (
+    <div
+      role="tabpanel"
+      aria-labelledby="Tokens"
+      className="clusterlist-table-container"
+    >
+      <TablePagination
+        data={tableRows}
+        id="pagination"
+        itemName="token"
+        className="u-no-margin--top"
+        aria-label="Table pagination control"
+      >
+        <MainTable
+          className={"clusterlist-table"}
+          responsive={true}
+          emptyStateMsg={
+            isLoading ? (
+              <Loader text="Loading Tokens..." />
+            ) : (
+              <>No tokens found.</>
+            )
+          }
+          headers={tableHeaders}
+          rows={tableRows}
+        />
+      </TablePagination>
+    </div>
+  );
+};
+
+export default ClusterListTokens;

--- a/ui/src/pages/clusters/PendingClusterActions.tsx
+++ b/ui/src/pages/clusters/PendingClusterActions.tsx
@@ -1,0 +1,19 @@
+import { FC } from "react";
+import DeleteClusterButton from "./DeleteClusterButton";
+import { Cluster } from "types/cluster";
+import ApproveClusterButton from "./ApproveClusterButton";
+
+interface Props {
+  cluster: Cluster;
+}
+
+const PendingClusterActions: FC<Props> = ({ cluster }) => {
+  return (
+    <div className="cluster-actions">
+      <ApproveClusterButton clusterName={cluster.name} />
+      <DeleteClusterButton clusterName={cluster.name} />
+    </div>
+  );
+};
+
+export default PendingClusterActions;

--- a/ui/src/types/token.d.ts
+++ b/ui/src/types/token.d.ts
@@ -1,0 +1,5 @@
+export interface Token {
+  created_at: string;
+  expiry: string;
+  site_name: string;
+}

--- a/ui/src/util/helpers.tsx
+++ b/ui/src/util/helpers.tsx
@@ -48,3 +48,18 @@ export const humanFileSize = (bytes: number): string => {
 
   return `${bytes.toFixed(1)} ${units[u]}`;
 };
+
+export const isoTimeToString = (isoTime: string): string => {
+  const date = new Date(isoTime);
+  if (date.getTime() === 0) {
+    return "Never";
+  }
+
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};

--- a/ui/src/util/queryKeys.tsx
+++ b/ui/src/util/queryKeys.tsx
@@ -1,4 +1,5 @@
 export const queryKeys = {
   clusters: "clusters",
   configOptions: "configOptions",
+  tokens: "tokens",
 };


### PR DESCRIPTION
Work Done:
- Created individual tables for Active and Pending clusters.
- Added a Token Table
- Added an API function to fetch Tokens
- Filtered clusters by status
- Added Token generation script to backend-init.
- Added "Add New Cluster" button.

![image](https://github.com/user-attachments/assets/522b25bf-c6bf-44dc-8b0c-051d22186ab7)

![image](https://github.com/user-attachments/assets/09a9e257-ef31-4851-95cd-4af98c4ceb69)

![image](https://github.com/user-attachments/assets/74807f21-05e9-418a-b6bb-3d00260eacc5)
