### PR TITLE
ui: add member configs to settings page [WD-12947]

### DIFF
--- a/cmd/lxd-site-mgr/configs.go
+++ b/cmd/lxd-site-mgr/configs.go
@@ -125,7 +125,9 @@ func isConfig(arg string) bool {
 
 func getMemberConfigs(args []string) (types.MemberConfigPatch, error) {
 	validMemberConfigKeys := types.ValidMemberConfigKeys()
-	configs := types.MemberConfigPatch{}
+	configs := types.MemberConfigPatch{
+		Config: make(map[types.MemberConfigKey]string),
+	}
 
 	for _, arg := range args {
 		if !isConfig(arg) {
@@ -133,15 +135,17 @@ func getMemberConfigs(args []string) (types.MemberConfigPatch, error) {
 		}
 
 		key, val := parseConfig(arg)
-		if _, ok := validMemberConfigKeys[key]; !ok {
+		memberConfigKey := types.MemberConfigKey(key)
+
+		if _, ok := validMemberConfigKeys[memberConfigKey]; !ok {
 			return types.MemberConfigPatch{}, fmt.Errorf("Invalid member config key: %s", key)
 		}
 
-		switch key {
-		case "https_address":
-			configs.HTTPSAddress = &val
-		case "external_address":
-			configs.ExternalAddress = &val
+		switch memberConfigKey {
+		case types.HTTPSAddress:
+			configs.Config[types.HTTPSAddress] = val
+		case types.ExternalAddress:
+			configs.Config[types.ExternalAddress] = val
 		}
 	}
 

--- a/cmd/lxd-site-mgr/configs.go
+++ b/cmd/lxd-site-mgr/configs.go
@@ -139,9 +139,9 @@ func getMemberConfigs(args []string) (types.MemberConfigPatch, error) {
 
 		switch key {
 		case "https_address":
-			configs.HTTPSAddress = val
+			configs.HTTPSAddress = &val
 		case "external_address":
-			configs.ExternalAddress = val
+			configs.ExternalAddress = &val
 		}
 	}
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/client"
+	"github.com/canonical/microcluster/rest/access"
 	microState "github.com/canonical/microcluster/state"
 
 	"github.com/canonical/lxd-site-manager/internal/api/types"
@@ -27,6 +29,16 @@ func authHandler(siteManagerState *state.SiteManagerState) types.AccessHandler {
 
 		_, resp, err := siteManagerState.OIDCVerifier.Auth(r.Context(), r)
 		if err != nil {
+			// check if the request is a cluster notification with valid cert
+			if client.IsNotification(r) && r.TLS != nil {
+				hostAddress := clusterState.Address().URL.Host
+				trustedCerts := clusterState.Remotes().CertificatesNative()
+				trusted, _ := access.Authenticate(clusterState, r, hostAddress, trustedCerts)
+				if trusted {
+					return true, nil
+				}
+			}
+
 			return false, resp
 		}
 

--- a/internal/api/manager_configs.go
+++ b/internal/api/manager_configs.go
@@ -51,7 +51,7 @@ func managerConfigPatch(siteManagerState *state.SiteManagerState) types.Endpoint
 			return response.BadRequest(fmt.Errorf("missing config key"))
 		}
 
-		err = types.ValidateConfigKeys(payload.Config)
+		err = types.ValidateManagerConfigKeys(payload.Config)
 		if err != nil {
 			return response.BadRequest(err)
 		}

--- a/internal/api/member_configs.go
+++ b/internal/api/member_configs.go
@@ -63,12 +63,12 @@ func memberConfigPatch(siteManagerState *state.SiteManagerState) types.EndpointH
 			return response.BadRequest(err)
 		}
 
-		if payload.HTTPSAddress == "" && payload.ExternalAddress == "" {
+		if payload.HTTPSAddress == nil && payload.ExternalAddress == nil {
 			return response.BadRequest(fmt.Errorf("no fields provided to update"))
 		}
 
-		if payload.ExternalAddress != "" {
-			_, err = microTypes.ParseAddrPort(payload.ExternalAddress)
+		if payload.ExternalAddress != nil && *payload.ExternalAddress != "" {
+			_, err = microTypes.ParseAddrPort(*payload.ExternalAddress)
 			if err != nil {
 				return response.BadRequest(fmt.Errorf("invalid external_address for member %q: %w", memberName, err))
 			}
@@ -82,8 +82,8 @@ func memberConfigPatch(siteManagerState *state.SiteManagerState) types.EndpointH
 			return response.InternalError(fmt.Errorf("failed to get local client: %w", err))
 		}
 
-		if payload.HTTPSAddress != "" {
-			newAddress, err := microTypes.ParseAddrPort(payload.HTTPSAddress)
+		if payload.HTTPSAddress != nil {
+			newAddress, err := microTypes.ParseAddrPort(*payload.HTTPSAddress)
 			if err != nil {
 				return response.BadRequest(fmt.Errorf("invalid https_address for member %q: %w", memberName, err))
 			}
@@ -155,8 +155,8 @@ func memberConfigPatch(siteManagerState *state.SiteManagerState) types.EndpointH
 
 			// if no external address is provided, keep the existing one
 			externalAddress := dbConfigs[0].ExternalAddress
-			if payload.ExternalAddress != "" {
-				externalAddress = payload.ExternalAddress
+			if payload.ExternalAddress != nil {
+				externalAddress = *payload.ExternalAddress
 			}
 
 			serverConfigs, err := client.GetDaemonServerConfigs(r.Context(), localClient)
@@ -238,8 +238,8 @@ func toMemberConfigsAPI(dbConfigs []database.ManagerMemberConfig) []types.Member
 		memberConfigs = append(memberConfigs, types.MemberConfig{
 			Target: c.Target,
 			MemberConfigPatch: types.MemberConfigPatch{
-				HTTPSAddress:    c.HTTPSAddress,
-				ExternalAddress: c.ExternalAddress,
+				HTTPSAddress:    &c.HTTPSAddress,
+				ExternalAddress: &c.ExternalAddress,
 			},
 		})
 	}

--- a/internal/api/member_configs.go
+++ b/internal/api/member_configs.go
@@ -64,12 +64,15 @@ func memberConfigPatch(siteManagerState *state.SiteManagerState) types.EndpointH
 			return response.BadRequest(err)
 		}
 
-		if payload.HTTPSAddress == nil && payload.ExternalAddress == nil {
+		HTTPSAddress, hasHTTPSAddress := payload.Config[types.HTTPSAddress]
+		externalAddress, hasExternalAddress := payload.Config[types.ExternalAddress]
+
+		if !hasHTTPSAddress && !hasExternalAddress {
 			return response.BadRequest(fmt.Errorf("no fields provided to update"))
 		}
 
-		if payload.ExternalAddress != nil && *payload.ExternalAddress != "" {
-			_, err = microTypes.ParseAddrPort(*payload.ExternalAddress)
+		if hasExternalAddress && externalAddress != "" {
+			_, err = microTypes.ParseAddrPort(externalAddress)
 			if err != nil {
 				return response.BadRequest(fmt.Errorf("invalid external_address for member %q: %w", memberName, err))
 			}
@@ -83,8 +86,8 @@ func memberConfigPatch(siteManagerState *state.SiteManagerState) types.EndpointH
 			return response.InternalError(fmt.Errorf("failed to get client for member %q: %w", memberName, err))
 		}
 
-		if payload.HTTPSAddress != nil {
-			newAddress, err := microTypes.ParseAddrPort(*payload.HTTPSAddress)
+		if hasHTTPSAddress {
+			newAddress, err := microTypes.ParseAddrPort(HTTPSAddress)
 			if err != nil {
 				return response.BadRequest(fmt.Errorf("invalid https_address for member %q: %w", memberName, err))
 			}
@@ -92,6 +95,7 @@ func memberConfigPatch(siteManagerState *state.SiteManagerState) types.EndpointH
 			// the control listener address is stored in a member's local state directory
 			// we need to update the control listener address, we need to forward the request to the relevant member and let the update happen there
 			if memberName != clusterState.Name() {
+				queryClient.SetClusterNotification()
 				err = client.MemberConfigPatchCmd(r.Context(), queryClient, memberName, &payload)
 				if err != nil {
 					return response.InternalError(fmt.Errorf("failed to update member %q config: %w", memberName, err))
@@ -144,9 +148,8 @@ func memberConfigPatch(siteManagerState *state.SiteManagerState) types.EndpointH
 			}
 
 			// if no external address is provided, keep the existing one
-			externalAddress := dbConfigs[0].ExternalAddress
-			if payload.ExternalAddress != nil {
-				externalAddress = *payload.ExternalAddress
+			if !hasExternalAddress {
+				externalAddress = dbConfigs[0].ExternalAddress
 			}
 
 			serverConfigs, err := client.GetDaemonServerConfigs(r.Context(), queryClient)
@@ -228,8 +231,10 @@ func toMemberConfigsAPI(dbConfigs []database.ManagerMemberConfig) []types.Member
 		memberConfigs = append(memberConfigs, types.MemberConfig{
 			Target: c.Target,
 			MemberConfigPatch: types.MemberConfigPatch{
-				HTTPSAddress:    &c.HTTPSAddress,
-				ExternalAddress: &c.ExternalAddress,
+				Config: map[types.MemberConfigKey]string{
+					types.HTTPSAddress:    c.HTTPSAddress,
+					types.ExternalAddress: c.ExternalAddress,
+				},
 			},
 		})
 	}

--- a/internal/api/member_configs.go
+++ b/internal/api/member_configs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
+	microClient "github.com/canonical/microcluster/client"
 	"github.com/canonical/microcluster/rest"
 	microTypes "github.com/canonical/microcluster/rest/types"
 	clusterState "github.com/canonical/microcluster/state"
@@ -77,9 +78,9 @@ func memberConfigPatch(siteManagerState *state.SiteManagerState) types.EndpointH
 		reverter := revert.New()
 		defer reverter.Fail()
 
-		localClient, err := siteManagerState.MicroCluster.LocalClient()
+		queryClient, err := getClientByName(clusterState, siteManagerState, memberName)
 		if err != nil {
-			return response.InternalError(fmt.Errorf("failed to get local client: %w", err))
+			return response.InternalError(fmt.Errorf("failed to get client for member %q: %w", memberName, err))
 		}
 
 		if payload.HTTPSAddress != nil {
@@ -91,18 +92,7 @@ func memberConfigPatch(siteManagerState *state.SiteManagerState) types.EndpointH
 			// the control listener address is stored in a member's local state directory
 			// we need to update the control listener address, we need to forward the request to the relevant member and let the update happen there
 			if memberName != clusterState.Name() {
-				remotes := clusterState.Remotes().RemotesByName()
-				targetRemote, ok := remotes[memberName]
-				if !ok {
-					return response.NotFound(fmt.Errorf("member %q not found", memberName))
-				}
-
-				targetClient, err := siteManagerState.MicroCluster.RemoteClient(targetRemote.Address.String())
-				if err != nil {
-					return response.InternalError(fmt.Errorf("failed to get remote client for member %q: %w", memberName, err))
-				}
-
-				err = client.MemberConfigPatchCmd(r.Context(), targetClient, memberName, &payload)
+				err = client.MemberConfigPatchCmd(r.Context(), queryClient, memberName, &payload)
 				if err != nil {
 					return response.InternalError(fmt.Errorf("failed to update member %q config: %w", memberName, err))
 				}
@@ -112,7 +102,7 @@ func memberConfigPatch(siteManagerState *state.SiteManagerState) types.EndpointH
 
 			// update the control listener address for local member configs
 			newServerConfig := make(map[string]microTypes.ServerConfig)
-			existingServerConfig, err := client.GetDaemonServerConfigs(r.Context(), localClient)
+			existingServerConfig, err := client.GetDaemonServerConfigs(r.Context(), queryClient)
 			if err != nil {
 				return response.InternalError(fmt.Errorf("failed to get local member %q config: %w", memberName, err))
 			}
@@ -159,7 +149,7 @@ func memberConfigPatch(siteManagerState *state.SiteManagerState) types.EndpointH
 				externalAddress = *payload.ExternalAddress
 			}
 
-			serverConfigs, err := client.GetDaemonServerConfigs(r.Context(), localClient)
+			serverConfigs, err := client.GetDaemonServerConfigs(r.Context(), queryClient)
 			if err != nil {
 				return fmt.Errorf("failed to get local member %q config: %w", memberName, err)
 			}
@@ -245,4 +235,28 @@ func toMemberConfigsAPI(dbConfigs []database.ManagerMemberConfig) []types.Member
 	}
 
 	return memberConfigs
+}
+
+func getClientByName(clusterState clusterState.State, siteManagerState *state.SiteManagerState, name string) (*microClient.Client, error) {
+	if clusterState.Name() == name {
+		localClient, err := siteManagerState.MicroCluster.LocalClient()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get local client: %w", err)
+		}
+
+		return localClient, nil
+	}
+
+	remotes := clusterState.Remotes().RemotesByName()
+	targetRemote, ok := remotes[name]
+	if !ok {
+		return nil, fmt.Errorf("member %q not found", name)
+	}
+
+	client, err := siteManagerState.MicroCluster.RemoteClient(targetRemote.Address.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get remote client for member: %s", name)
+	}
+
+	return client, nil
 }

--- a/internal/api/types/manager_configs.go
+++ b/internal/api/types/manager_configs.go
@@ -17,8 +17,8 @@ func ValidManagerConfigKeys() map[string]bool {
 	}
 }
 
-// ValidateConfigKeys validates the given config keys that they exist in the map of valid config keys for site manager.
-func ValidateConfigKeys(config map[string]string) error {
+// ValidateManagerConfigKeys validates the given manager config keys that they exist in the map of valid config keys for site manager.
+func ValidateManagerConfigKeys(config map[string]string) error {
 	for k := range config {
 		_, ok := ValidManagerConfigKeys()[k]
 		if !ok {

--- a/internal/api/types/member_configs.go
+++ b/internal/api/types/member_configs.go
@@ -2,8 +2,8 @@ package types
 
 // MemberConfigPatch represents the payload required to update configs for a single site manager member.
 type MemberConfigPatch struct {
-	HTTPSAddress    string `json:"https_address,omitempty"`
-	ExternalAddress string `json:"external_address,omitempty"`
+	HTTPSAddress    *string `json:"https_address,omitempty"`
+	ExternalAddress *string `json:"external_address,omitempty"`
 }
 
 // MemberConfig represents config data for a single site manager member, which includes the member name.

--- a/internal/api/types/member_configs.go
+++ b/internal/api/types/member_configs.go
@@ -1,9 +1,17 @@
 package types
 
+// MemberConfigKey represents the valid keys for site manager member configs.
+type MemberConfigKey string
+
+// Valid member config keys.
+const (
+	HTTPSAddress    MemberConfigKey = "https_address"
+	ExternalAddress MemberConfigKey = "external_address"
+)
+
 // MemberConfigPatch represents the payload required to update configs for a single site manager member.
 type MemberConfigPatch struct {
-	HTTPSAddress    *string `json:"https_address,omitempty"`
-	ExternalAddress *string `json:"external_address,omitempty"`
+	Config map[MemberConfigKey]string `json:"config" yaml:"config"`
 }
 
 // MemberConfig represents config data for a single site manager member, which includes the member name.
@@ -13,9 +21,9 @@ type MemberConfig struct {
 }
 
 // ValidMemberConfigKeys returns a map of valid member config keys.
-func ValidMemberConfigKeys() map[string]bool {
-	return map[string]bool{
-		"https_address":    true,
-		"external_address": true,
+func ValidMemberConfigKeys() map[MemberConfigKey]bool {
+	return map[MemberConfigKey]bool{
+		HTTPSAddress:    true,
+		ExternalAddress: true,
 	}
 }

--- a/ui/src/api/settings.ts
+++ b/ui/src/api/settings.ts
@@ -42,7 +42,7 @@ export const updateMemberConfigs = (
     fetch(`/1.0/member/${member}/config`, {
       method: "PATCH",
       body: JSON.stringify({
-        ...config,
+        config,
       }),
     })
       .then(handleResponse)

--- a/ui/src/api/settings.ts
+++ b/ui/src/api/settings.ts
@@ -1,8 +1,8 @@
 import { LxdApiResponse } from "types/apiResponse";
-import { LxdConfigPair, ManagerOptions } from "types/config";
+import { ConfigPair, ManagerOptions, MemberOptions } from "types/config";
 import { handleResponse } from "util/helpers";
 
-export const fetchConfigOptions = (): Promise<ManagerOptions> => {
+export const fetchManagerConfigOptions = (): Promise<ManagerOptions> => {
   return new Promise((resolve, reject) => {
     fetch("/1.0/config")
       .then(handleResponse)
@@ -11,12 +11,38 @@ export const fetchConfigOptions = (): Promise<ManagerOptions> => {
   });
 };
 
-export const updateSettings = (config: LxdConfigPair): Promise<void> => {
+export const updateManagerConfigs = (config: ConfigPair): Promise<void> => {
   return new Promise((resolve, reject) => {
     fetch("/1.0/config", {
       method: "PATCH",
       body: JSON.stringify({
         config,
+      }),
+    })
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
+export const fetchMemberConfigOptions = (): Promise<MemberOptions[]> => {
+  return new Promise((resolve, reject) => {
+    fetch("/1.0/member/config")
+      .then(handleResponse)
+      .then((data: LxdApiResponse<MemberOptions[]>) => resolve(data.metadata))
+      .catch(reject);
+  });
+};
+
+export const updateMemberConfigs = (
+  member: string,
+  config: ConfigPair,
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/member/${member}/config`, {
+      method: "PATCH",
+      body: JSON.stringify({
+        ...config,
       }),
     })
       .then(handleResponse)

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -29,7 +29,7 @@ const Settings: FC = () => {
     "global.address": "",
   };
 
-  const defaultMemberConfigs: MemberOptions = {
+  const defaultMemberConfigs: MemberOptions["config"] = {
     https_address: "",
     external_address: "",
   };
@@ -87,7 +87,7 @@ const Settings: FC = () => {
 
     for (const memberConfig of memberConfigOptions) {
       const configKeys = Object.keys(defaultMemberConfigs) as Array<
-        keyof MemberOptions
+        keyof MemberOptions["config"]
       >;
 
       const currentMemberConfigRows = configKeys.map((key, index) => {
@@ -124,7 +124,7 @@ const Settings: FC = () => {
               content: (
                 <SettingForm
                   configField={key}
-                  value={memberConfig[key] || defaultMemberConfigs[key]}
+                  value={memberConfig.config[key] || defaultMemberConfigs[key]}
                   isLast={index === length - 1}
                   member={memberConfig.target}
                 />

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -2,21 +2,36 @@ import { FC } from "react";
 import { MainTable, Row } from "@canonical/react-components";
 import BaseLayout from "components/BaseLayout";
 import { queryKeys } from "util/queryKeys";
-import { fetchConfigOptions } from "api/settings";
+import {
+  fetchManagerConfigOptions,
+  fetchMemberConfigOptions,
+} from "api/settings";
 import { useQuery } from "@tanstack/react-query";
 import SettingForm from "./settings/SettingForm";
+import { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import { MemberOptions } from "types/config";
 
 const Settings: FC = () => {
-  const { data: configOptions } = useQuery({
-    queryKey: [queryKeys.configOptions],
-    queryFn: fetchConfigOptions,
+  const { data: managerConfigOptions } = useQuery({
+    queryKey: [queryKeys.managerConfigOptions],
+    queryFn: fetchManagerConfigOptions,
   });
 
-  const defaultConfig = {
+  const { data: memberConfigOptions = [] } = useQuery({
+    queryKey: [queryKeys.memberConfigOptions],
+    queryFn: fetchMemberConfigOptions,
+  });
+
+  const defaultManagerConfigs = {
     "oidc.issuer": "",
     "oidc.client.id": "",
     "oidc.audience": "",
     "global.address": "",
+  };
+
+  const defaultMemberConfigs = {
+    https_address: "",
+    external_address: "",
   };
 
   const headers = [
@@ -25,44 +40,104 @@ const Settings: FC = () => {
     { content: "Value" },
   ];
 
-  const configKeys = Object.keys(defaultConfig);
-  // const configKeys = Object.keys(defaultConfig);
+  const generateManagerConfigRows = () => {
+    const configKeys = Object.keys(defaultManagerConfigs);
+    const rows = configKeys.map((key, index) => {
+      return {
+        columns: [
+          {
+            content: (
+              <h2 className="p-heading--5">{index === 0 ? "Cluster" : ""}</h2>
+            ),
+            role: "cell",
+            className: "scope",
+            "aria-label": "Scope",
+          },
+          {
+            content: <div className="key-cell">{key}</div>,
+            role: "cell",
+            className: "key",
+            "aria-label": "Key",
+          },
+          {
+            content: (
+              <SettingForm
+                configField={key}
+                value={
+                  managerConfigOptions?.config[key] ||
+                  defaultManagerConfigs[
+                    key as keyof typeof defaultManagerConfigs
+                  ]
+                }
+                isLast={index === length - 1}
+              />
+            ),
+            role: "cell",
+            "aria-label": "Value",
+            className: "u-vertical-align-middle",
+          },
+        ],
+      };
+    });
 
-  const rows = configKeys.map((key, index) => {
-    return {
-      columns: [
-        {
-          content: (
-            <h2 className="p-heading--5">{index === 0 ? "Cluster" : ""}</h2>
-          ),
-          role: "cell",
-          className: "scope",
-          "aria-label": "Scope",
-        },
-        {
-          content: <div className="key-cell">{key}</div>,
-          role: "cell",
-          className: "key",
-          "aria-label": "Key",
-        },
-        {
-          content: (
-            <SettingForm
-              configField={key}
-              value={
-                configOptions?.config[key] ||
-                defaultConfig[key as keyof typeof defaultConfig]
-              }
-              isLast={index === length - 1}
-            />
-          ),
-          role: "cell",
-          "aria-label": "Value",
-          className: "u-vertical-align-middle",
-        },
-      ],
-    };
-  });
+    return rows;
+  };
+
+  const generateMemberConfigRows = () => {
+    const allMemberConfigRows: MainTableRow[] = [];
+
+    for (const memberConfig of memberConfigOptions) {
+      const configKeys = Object.keys(defaultMemberConfigs);
+      const currentMemberConfigRows = configKeys.map((key, index) => {
+        return {
+          columns: [
+            {
+              content: (
+                <h2 className="p-heading--5">
+                  {index === 0 ? memberConfig.target : ""}
+                </h2>
+              ),
+              role: "cell",
+              className: "scope",
+              "aria-label": "Scope",
+            },
+            {
+              content: (
+                <div className="key-cell">{`${memberConfig.target}.${key}`}</div>
+              ),
+              role: "cell",
+              className: "key",
+              "aria-label": "Key",
+            },
+            {
+              content: (
+                <SettingForm
+                  configField={key}
+                  value={
+                    memberConfig[key as keyof MemberOptions] ||
+                    defaultMemberConfigs[
+                      key as keyof typeof defaultMemberConfigs
+                    ]
+                  }
+                  isLast={index === length - 1}
+                  member={memberConfig.target}
+                />
+              ),
+              role: "cell",
+              "aria-label": "Value",
+              className: "u-vertical-align-middle",
+            },
+          ],
+        };
+      });
+
+      allMemberConfigRows.push(...currentMemberConfigRows);
+    }
+
+    return allMemberConfigRows;
+  };
+
+  const rows = [...generateManagerConfigRows(), ...generateMemberConfigRows()];
 
   return (
     <BaseLayout title="Settings">

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -9,7 +9,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import SettingForm from "./settings/SettingForm";
 import { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
-import { MemberOptions } from "types/config";
+import { ManagerOptions, MemberOptions } from "types/config";
 
 const Settings: FC = () => {
   const { data: managerConfigOptions } = useQuery({
@@ -22,14 +22,14 @@ const Settings: FC = () => {
     queryFn: fetchMemberConfigOptions,
   });
 
-  const defaultManagerConfigs = {
+  const defaultManagerConfigs: ManagerOptions["config"] = {
     "oidc.issuer": "",
     "oidc.client.id": "",
     "oidc.audience": "",
     "global.address": "",
   };
 
-  const defaultMemberConfigs = {
+  const defaultMemberConfigs: MemberOptions = {
     https_address: "",
     external_address: "",
   };
@@ -42,6 +42,7 @@ const Settings: FC = () => {
 
   const generateManagerConfigRows = () => {
     const configKeys = Object.keys(defaultManagerConfigs);
+
     const rows = configKeys.map((key, index) => {
       return {
         columns: [
@@ -65,9 +66,7 @@ const Settings: FC = () => {
                 configField={key}
                 value={
                   managerConfigOptions?.config[key] ||
-                  defaultManagerConfigs[
-                    key as keyof typeof defaultManagerConfigs
-                  ]
+                  defaultManagerConfigs[key]
                 }
                 isLast={index === length - 1}
               />
@@ -87,14 +86,24 @@ const Settings: FC = () => {
     const allMemberConfigRows: MainTableRow[] = [];
 
     for (const memberConfig of memberConfigOptions) {
-      const configKeys = Object.keys(defaultMemberConfigs);
+      const configKeys = Object.keys(defaultMemberConfigs) as Array<
+        keyof MemberOptions
+      >;
+
       const currentMemberConfigRows = configKeys.map((key, index) => {
+        const memberConfigScope =
+          index === 0 ? `Member (${memberConfig.target})` : "";
+        const memberConfigKey = `${memberConfig.target}.${key}`;
+
         return {
           columns: [
             {
               content: (
-                <h2 className="p-heading--5">
-                  {index === 0 ? memberConfig.target : ""}
+                <h2
+                  className="p-heading--5 u-truncate"
+                  title={memberConfigScope}
+                >
+                  {memberConfigScope}
                 </h2>
               ),
               role: "cell",
@@ -103,7 +112,9 @@ const Settings: FC = () => {
             },
             {
               content: (
-                <div className="key-cell">{`${memberConfig.target}.${key}`}</div>
+                <div className="key-cell u-truncate" title={memberConfigKey}>
+                  {memberConfigKey}
+                </div>
               ),
               role: "cell",
               className: "key",
@@ -113,12 +124,7 @@ const Settings: FC = () => {
               content: (
                 <SettingForm
                   configField={key}
-                  value={
-                    memberConfig[key as keyof MemberOptions] ||
-                    defaultMemberConfigs[
-                      key as keyof typeof defaultMemberConfigs
-                    ]
-                  }
+                  value={memberConfig[key] || defaultMemberConfigs[key]}
                   isLast={index === length - 1}
                   member={memberConfig.target}
                 />

--- a/ui/src/pages/settings/SettingForm.tsx
+++ b/ui/src/pages/settings/SettingForm.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useRef, useState } from "react";
 import { Button, Icon, useNotify } from "@canonical/react-components";
-import { updateSettings } from "api/settings";
+import { updateManagerConfigs, updateMemberConfigs } from "api/settings";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import SettingFormInput from "./SettingFormInput";
@@ -9,9 +9,10 @@ interface Props {
   configField: string;
   value?: string;
   isLast?: boolean;
+  member?: string;
 }
 
-const SettingForm: FC<Props> = ({ configField, value, isLast }) => {
+const SettingForm: FC<Props> = ({ configField, value, isLast, member }) => {
   const [isEditMode, setEditMode] = useState(false);
   const notify = useNotify();
   const queryClient = useQueryClient();
@@ -22,7 +23,11 @@ const SettingForm: FC<Props> = ({ configField, value, isLast }) => {
     const config = {
       [configField]: String(newValue),
     };
-    updateSettings(config)
+
+    (member
+      ? updateMemberConfigs(member, config)
+      : updateManagerConfigs(config)
+    )
       .then(() => {
         setEditMode(false);
       })
@@ -31,7 +36,11 @@ const SettingForm: FC<Props> = ({ configField, value, isLast }) => {
       })
       .finally(() => {
         void queryClient.invalidateQueries({
-          queryKey: [queryKeys.configOptions],
+          queryKey: [
+            member
+              ? queryKeys.memberConfigOptions
+              : queryKeys.managerConfigOptions,
+          ],
         });
       });
   };

--- a/ui/src/pages/settings/SettingFormInput.tsx
+++ b/ui/src/pages/settings/SettingFormInput.tsx
@@ -44,7 +44,7 @@ const SettingFormInput: FC<Props> = ({
       <Button appearance="base" onClick={onCancel}>
         Cancel
       </Button>
-      <Button appearance="positive" onClick={() => onSubmit(value)}>
+      <Button appearance="positive" type="submit">
         Save
       </Button>
     </Form>

--- a/ui/src/sass/_settings_page.scss
+++ b/ui/src/sass/_settings_page.scss
@@ -2,7 +2,7 @@
   min-height: initial !important;
 
   .scope {
-    width: 8rem;
+    width: 14rem;
 
     @include mobile {
       display: none;

--- a/ui/src/types/config.d.ts
+++ b/ui/src/types/config.d.ts
@@ -8,6 +8,8 @@ interface ManagerOptions {
 
 interface MemberOptions {
   target?: string;
-  https_address: string;
-  external_address?: string;
+  config: {
+    https_address: string;
+    external_address?: string;
+  };
 }

--- a/ui/src/types/config.d.ts
+++ b/ui/src/types/config.d.ts
@@ -1,7 +1,13 @@
-export type LxdConfigPair = Record<string, string | undefined>;
+export type ConfigPair = Record<string, string | undefined>;
 
 interface ManagerOptions {
   config: {
     [key: string]: string;
   };
+}
+
+interface MemberOptions {
+  target: string;
+  https_address: string;
+  external_address?: string;
 }

--- a/ui/src/types/config.d.ts
+++ b/ui/src/types/config.d.ts
@@ -7,7 +7,7 @@ interface ManagerOptions {
 }
 
 interface MemberOptions {
-  target: string;
+  target?: string;
   https_address: string;
   external_address?: string;
 }

--- a/ui/src/util/queryKeys.tsx
+++ b/ui/src/util/queryKeys.tsx
@@ -1,5 +1,6 @@
 export const queryKeys = {
   clusters: "clusters",
-  configOptions: "configOptions",
+  managerConfigOptions: "managerConfigOptions",
+  memberConfigOptions: "memberConfigOptions",
   tokens: "tokens",
 };


### PR DESCRIPTION
## Done
- Added member configs to settings page
- Allow reset external address for members
- Use correct client for updating member configs. Previously a bug was introduced where we'd use a local client to get a remote member's server configs for updating the same entry in the database.

## Context
With #47 merged, it is now guaranteed that every member in the cluster will have configs in the `manager_member_configs` table during initialisation. So member configs will show in the settings page by default with its `https_address` setting.