### PR TITLE
experimental: allow forwarding idp callback request to cluster member that initiated the oidc login flow [WD-13323]

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/microcluster/rest"
@@ -9,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/canonical/lxd-site-manager/internal/api/types"
+	"github.com/canonical/lxd-site-manager/internal/client"
 	"github.com/canonical/lxd-site-manager/internal/oidc"
 	"github.com/canonical/lxd-site-manager/internal/state"
 )
@@ -24,6 +28,10 @@ var oidcCallbackCmd = func(s *state.SiteManagerState) rest.Endpoint {
 	return rest.Endpoint{
 		Path: "oidc/callback",
 		Get:  rest.EndpointAction{Handler: oidcCallback(s), AllowUntrusted: true},
+		// FIXME: microcluster does not allow adjusting requets headers when forwarding requests using built-in client functions
+		// This is the reason why we need this POST /oidc/callback endpoint so that we can forward cookies in the request payload
+		// We should remove this endpoint once the microcluster is updated to allow adjusting request headers
+		Post: rest.EndpointAction{Handler: oidcCallback(s), AllowUntrusted: true},
 	}
 }
 
@@ -39,8 +47,9 @@ func oidcLogin(s *state.SiteManagerState) types.EndpointHandler {
 		redirectURL := r.URL.Query().Get("next")
 
 		stateToken := oidc.StateToken{
-			RedirectURL: redirectURL,
-			ID:          uuid.New().String(),
+			MemberAddress: innerState.Address().URL.String(),
+			RedirectURL:   redirectURL,
+			ID:            uuid.New().String(),
 		}
 
 		state, err := stateToken.String()
@@ -59,19 +68,90 @@ func oidcLogin(s *state.SiteManagerState) types.EndpointHandler {
 
 func oidcCallback(s *state.SiteManagerState) types.EndpointHandler {
 	return func(innerState microState.State, r *http.Request) response.Response {
-		state := r.URL.Query().Get("state")
-		stateToken, err := oidc.DecodeStateToken(state)
-		if err != nil {
-			return response.InternalError(err)
+		// FIXME: We have to set the forwarded query parameter for a forwarded request because microcluster does not allow adjusting request headers
+		// We should remove this once the microcluster is updated to allow adjusting request headers
+		forwarded := r.URL.Query().Get("forwarded")
+		if forwarded != "" {
+			return handleForwardedCallback(s, r)
 		}
 
-		callbackHandler := func(w http.ResponseWriter) error {
-			s.OIDCVerifier.Callback(w, r, stateToken.RedirectURL)
-			return nil
-		}
-
-		return response.ManualResponse(callbackHandler)
+		return handleCallback(s, innerState, r)
 	}
+}
+
+func handleCallback(siteManagerState *state.SiteManagerState, microState microState.State, r *http.Request) response.Response {
+	state := r.URL.Query().Get("state")
+	stateToken, err := oidc.DecodeStateToken(state)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	// If the member address in the state token is different from the current member address, then forward the request to the correct member
+	currentMemberAddress := microState.Address().URL.String()
+	if stateToken.MemberAddress != currentMemberAddress {
+		url, err := url.Parse(stateToken.MemberAddress)
+		if err != nil {
+			return response.SmartError(fmt.Errorf("Failed to parse member address %q: %w", stateToken.MemberAddress, err))
+		}
+
+		targetClient, err := siteManagerState.MicroCluster.RemoteClient(url.Host)
+		if err != nil {
+			return response.SmartError(fmt.Errorf("Failed to get a client for cluster member with address %q: %w", stateToken.MemberAddress, err))
+		}
+
+		// Forward the request to the target client
+		// FIXME: currently microcluser does not return a response from the client function
+		// Once this is fixed, we should return the response from the client function since cookies would be set already in the response
+		// Then we could just copy over the cookies from the response to the current response
+		tokens, err := client.CallbackForwardCmd(r.Context(), targetClient, r)
+		if err != nil {
+			targetClientURL := targetClient.URL()
+			return response.SmartError(fmt.Errorf("Failed to GET from cluster member with address %q: %w", targetClientURL.String(), err))
+		}
+
+		// Write the tokens to the cookies and redirect to the UI
+		return response.ManualResponse(func(w http.ResponseWriter) error {
+			err := siteManagerState.OIDCVerifier.WriteTokenToCookies(w, tokens.IDToken, tokens.RefreshToken)
+			if err != nil {
+				return err
+			}
+
+			http.Redirect(w, r, stateToken.RedirectURL, http.StatusMovedPermanently)
+			return nil
+		})
+	}
+
+	// If the member address in the state token is the same as the current member address, then handle the callback locally
+	callbackHandler := func(w http.ResponseWriter) error {
+		siteManagerState.OIDCVerifier.Callback(w, r, stateToken.RedirectURL)
+		return nil
+	}
+
+	return response.ManualResponse(callbackHandler)
+}
+
+func handleForwardedCallback(siteManagerState *state.SiteManagerState, r *http.Request) response.Response {
+	var payload types.AuthCallbackPost
+	err := json.NewDecoder(r.Body).Decode(&payload)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// For a forwarded request, we need to align the request host with the oidc verifier host so that we can ensure we don't reinitiate the oidc relying party
+	r.Host = siteManagerState.OIDCVerifier.Host()
+
+	// Add all the cookies from the source request to the current request so that the oidc relying party can use the same cookies
+	// FIXME: we can get cookies from request header instead once microcluster is updated to allow adjusting request headers
+	for _, cookie := range payload.Cookies {
+		r.AddCookie(&cookie)
+	}
+
+	callbackHandler := func(w http.ResponseWriter) error {
+		siteManagerState.OIDCVerifier.Callback(w, r, "")
+		return nil
+	}
+
+	return response.ManualResponse(callbackHandler)
 }
 
 func oidcLogout(s *state.SiteManagerState) types.EndpointHandler {

--- a/internal/api/types/auth.go
+++ b/internal/api/types/auth.go
@@ -1,0 +1,8 @@
+package types
+
+import "net/http"
+
+// AuthCallbackPost represents the request body for the oidc/callback endpoint for a forwarded request.
+type AuthCallbackPost struct {
+	Cookies []http.Cookie `json:"cookies"`
+}

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -1,0 +1,63 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/microcluster/client"
+
+	"github.com/canonical/lxd-site-manager/internal/api/types"
+	"github.com/canonical/lxd-site-manager/internal/oidc"
+)
+
+// CallbackForwardCmd forwards a oidc callback request to the oidc/callback endpoint on.
+func CallbackForwardCmd(ctx context.Context, c *client.Client, sourceRequest *http.Request) (oidc.OidcTokens, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	// Get all the source query params and append it to the target URL
+	sourceQueryParams := sourceRequest.URL.Query()
+	targetURL := api.NewURL().Path("oidc", "callback")
+	targetQueryParams := targetURL.Query()
+	for key, values := range sourceQueryParams {
+		for _, value := range values {
+			targetQueryParams.Add(key, value)
+		}
+	}
+
+	// FIXME: microcluster does not allow adjusting requets headers when forwarding requests using built-in client functions
+	// This is the reason why we need to set the forwarded query parameter for a forwarded request
+	// We should remove this once the microcluster is updated to allow adjusting request headers
+	targetQueryParams.Add("forwarded", "true")
+	targetURL.RawQuery = targetQueryParams.Encode()
+
+	// Clear the raw path, this causes the endpoint to not be found when forwarding the request
+	targetURL.RawPath = ""
+
+	// Get all the source cookies and append it to the payload
+	// FIXME: instead of forwarding cookies in the payload, we should forward them in the request headers
+	// We should remove this once the microcluster is updated to allow adjusting request headers
+	cookies := sourceRequest.Cookies()
+	var cookieSlice []http.Cookie
+	for _, cookie := range cookies {
+		cookieSlice = append(cookieSlice, *cookie)
+	}
+
+	payload := types.AuthCallbackPost{
+		Cookies: cookieSlice,
+	}
+
+	var out oidc.OidcTokens
+	// FIXME: if we can adjust the request headers, we should forward the cookies in the request headers
+	// We should use the GET endpoint and remove the POST endpoint once microcluster is updated to allow adjusting request headers
+	err := c.Query(queryCtx, "POST", types.NoPrefix, targetURL, payload, &out)
+	if err != nil {
+		clientURL := c.URL()
+		return oidc.OidcTokens{}, fmt.Errorf("Failed performing action on %q: %w", clientURL.String(), err)
+	}
+
+	return out, nil
+}

--- a/internal/oidc/oidc.go
+++ b/internal/oidc/oidc.go
@@ -81,11 +81,13 @@ func (e AuthError) Unwrap() error {
 }
 
 // StateToken is used to encode the state of the OIDC client in a URL which is used to prevent CSRF attacks (https://datatracker.ietf.org/doc/html/rfc6749#section-10.12).
+// MemberAddress is the address of the member that initiated the login flow. In a distributed system, we can use this address to ensure that the login flow is completed on the same member.
 // RedirectURL is the URL to which the client will be redirected after authentication.
 // ID is a unique identifier for the state token and therefore the current login session.
 type StateToken struct {
-	RedirectURL string
-	ID          string
+	MemberAddress string
+	RedirectURL   string
+	ID            string
 }
 
 // String encodes the StateToken as a base64 encoded string.
@@ -112,6 +114,13 @@ func DecodeStateToken(token string) (StateToken, error) {
 	}
 
 	return stateToken, nil
+}
+
+// OidcTokens represents the ID and refresh tokens.
+// These tokens will only be returned to a client from within the cluster.
+type OidcTokens struct {
+	IDToken      string `json:"id_token"`
+	RefreshToken string `json:"refresh_token"`
 }
 
 // Auth extracts OIDC tokens from the request, verifies them, and returns the subject.
@@ -240,9 +249,14 @@ func (o *Verifier) Callback(w http.ResponseWriter, r *http.Request, redirectURL 
 			_ = response.ErrorResponse(http.StatusInternalServerError, err.Error()).Render(w)
 		}
 
-		// Send to the UI.
-		// NOTE: Once the UI does the redirection on its own, we may be able to use the referer here instead.
-		http.Redirect(w, r, redirectURL, http.StatusMovedPermanently)
+		if redirectURL != "" {
+			// Send to the UI.
+			// NOTE: Once the UI does the redirection on its own, we may be able to use the referer here instead.
+			http.Redirect(w, r, redirectURL, http.StatusMovedPermanently)
+			return
+		}
+
+		_ = response.SyncResponse(true, OidcTokens{IDToken: tokens.IDToken, RefreshToken: tokens.RefreshToken}).Render(w)
 	}, o.relyingParty)
 
 	handler(w, r)


### PR DESCRIPTION
## Context
This is reference PR to demonstrate the following approach for handling oidc callback request in a cluster where the member receiving the request is different to the member that initiated the login flow.

1. create a encoded state token with id and member address in /oidc/login endpoint
2. redirect to idp with the state token
3. when receiving the callback request, decode the state token and check if the member address is the same as the current member.
   If it's the same, process the request with token exchange and establish session.
4. if not, forward the request to the correct member based on the member address in the state token.
   As part of this process, we also ensure if the address in the state token matches no members in the cluster, we abort the login flow
5. to forward the request, we need to ensure the following:
    - the original request query parameters are preserved ("code" and "state")
    - the original request cookies are preserved (currently this is sent in the body of a POST request due to microcluster not having the ability to adjust headers in a client request)
    - the original request HOST header is preserved (also sent in the payload of the POST request). This is needed so that on the target member, we don't reinitiate the oidc configs
6. the target member will then process the request as if it was the original member that initiated the login flow
7. the target member will then send the response with id and refresh tokens back to the original member that received the callback request
8. the original member will then establish the session with the id and refresh tokens
9. future authentication checks will pass regardless of which member receives the request since the session cookies are encrypted with the cluster certificate.

This approach is by no means final and we should rather use the approach implemented in LXD to address this upstream [issue](https://github.com/canonical/lxd/issues/13644).