### PR TITLE
feat(user-info): add /1.0 endpoint to retrieve user info and authentication state [WD-12702]

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/canonical/lxd/lxd/response"
@@ -9,6 +10,7 @@ import (
 	microState "github.com/canonical/microcluster/state"
 
 	"github.com/canonical/lxd-site-manager/internal/api/types"
+	"github.com/canonical/lxd-site-manager/internal/oidc"
 	"github.com/canonical/lxd-site-manager/internal/state"
 )
 
@@ -27,7 +29,7 @@ func authHandler(siteManagerState *state.SiteManagerState) types.AccessHandler {
 			return false, response.Forbidden(nil)
 		}
 
-		_, resp, err := siteManagerState.OIDCVerifier.Auth(r.Context(), r)
+		result, resp, err := siteManagerState.OIDCVerifier.Auth(r.Context(), r)
 		if err != nil {
 			// check if the request is a cluster notification with valid cert
 			if client.IsNotification(r) && r.TLS != nil {
@@ -39,9 +41,27 @@ func authHandler(siteManagerState *state.SiteManagerState) types.AccessHandler {
 				}
 			}
 
+			if r.URL.Path == "/1.0" {
+				return false, response.SyncResponse(false, types.APIRoot{
+					Trusted: false,
+				})
+			}
+
 			return false, resp
 		}
 
+		setUserInfoInRequest(result, r)
+
 		return true, resp
 	}
+}
+
+func setUserInfoInRequest(authResult *oidc.AuthenticationResult, r *http.Request) {
+	userInfo := &types.UserInfo{
+		Email: authResult.Email,
+		Name:  authResult.Name,
+	}
+
+	userInfoCtx := context.WithValue(r.Context(), types.UserInfoKey, userInfo)
+	*r = *r.WithContext(userInfoCtx)
 }

--- a/internal/api/api_root.go
+++ b/internal/api/api_root.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/rest"
+	microState "github.com/canonical/microcluster/state"
+
+	"github.com/canonical/lxd-site-manager/internal/api/types"
+	"github.com/canonical/lxd-site-manager/internal/state"
+)
+
+func apiRootCmd(s *state.SiteManagerState) rest.Endpoint {
+	return rest.Endpoint{
+		Path: "",
+		Get: rest.EndpointAction{
+			Handler:        apiRootGet,
+			AllowUntrusted: true,
+			AccessHandler:  authHandler(s),
+		},
+	}
+}
+
+func apiRootGet(s microState.State, r *http.Request) response.Response {
+	userInfo, ok := r.Context().Value(types.UserInfoKey).(*types.UserInfo)
+	if !ok {
+		return response.InternalError(fmt.Errorf("failed to get user information from the request context"))
+	}
+
+	systemInfo := types.APIRoot{
+		UserInfo: *userInfo,
+		Trusted:  true,
+	}
+
+	return response.SyncResponse(true, systemInfo)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -37,6 +37,7 @@ func siteManagementListener(s *state.SiteManagerState) rest.Server {
 			{
 				PathPrefix: types.APIVersionPrefix,
 				Endpoints: []rest.Endpoint{
+					apiRootCmd(s),
 					siteCmd(s),
 					sitesCmd(s),
 					managerConfigsCmd(s),

--- a/internal/api/types/api_root.go
+++ b/internal/api/types/api_root.go
@@ -1,0 +1,18 @@
+package types
+
+type userContextKey string
+
+// UserInfoKey is the key used to store the user information in the request context.
+const UserInfoKey userContextKey = "user-info"
+
+// UserInfo represents the information about a user.
+type UserInfo struct {
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
+// APIRoot represents environment data for the site manager.
+type APIRoot struct {
+	UserInfo
+	Trusted bool `json:"trusted"`
+}

--- a/ui/src/api/server.ts
+++ b/ui/src/api/server.ts
@@ -1,0 +1,12 @@
+import { LxdApiResponse } from "types/apiResponse";
+import { Server } from "types/server";
+import { handleResponse } from "util/helpers";
+
+export const fetchServer = (): Promise<Server> => {
+  return new Promise((resolve, reject) => {
+    fetch("/1.0")
+      .then(handleResponse)
+      .then((data: LxdApiResponse<Server>) => resolve(data.metadata))
+      .catch(reject);
+  });
+};

--- a/ui/src/context/auth.tsx
+++ b/ui/src/context/auth.tsx
@@ -1,7 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
-import { fetchClusters } from "api/clusters";
 import { createContext, FC, ReactNode, useContext } from "react";
-import { queryKeys } from "util/queryKeys";
+import { useServer } from "./useServer";
 
 interface ContextProps {
   isAuthenticated: boolean;
@@ -20,14 +18,9 @@ interface ProviderProps {
 }
 
 export const AuthProvider: FC<ProviderProps> = ({ children }) => {
-  // FIXME: this should query /1.0 when the endpoint is ready to check if the user is authenticated
-  const { error, isLoading } = useQuery({
-    queryKey: [queryKeys.clusters],
-    queryFn: fetchClusters,
-    retry: false,
-  });
+  const { data: server, isLoading } = useServer();
 
-  const isAuthenticated = !isLoading && error?.message !== "not authorized";
+  const isAuthenticated = !isLoading && !!server?.trusted;
 
   return (
     <AuthContext.Provider

--- a/ui/src/context/useServer.tsx
+++ b/ui/src/context/useServer.tsx
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { UseQueryResult } from "@tanstack/react-query/src/types";
+import { Server } from "types/server";
+import { fetchServer } from "api/server";
+
+export const useServer = (): UseQueryResult<Server> => {
+  return useQuery({
+    queryKey: [queryKeys.server],
+    queryFn: fetchServer,
+  });
+};

--- a/ui/src/types/server.d.ts
+++ b/ui/src/types/server.d.ts
@@ -1,0 +1,5 @@
+export interface Server {
+  email: string;
+  name: string;
+  trusted: boolean;
+}

--- a/ui/src/util/queryKeys.tsx
+++ b/ui/src/util/queryKeys.tsx
@@ -3,4 +3,5 @@ export const queryKeys = {
   managerConfigOptions: "managerConfigOptions",
   memberConfigOptions: "memberConfigOptions",
   tokens: "tokens",
+  server: "server",
 };


### PR DESCRIPTION
## Done
- added `GET /1.0` endpoint to return user info and authentication state
- adjust ui auth check to use `GET /1.0` endpoint

## QA
- make sure you are logged out. Enter `https://0.0.0.0:8414/1.0` in the browser url. You should get back the following payload
```
{
  "type": "sync",
  "status": "Failure",
  "status_code": 400,
  "operation": "",
  "error_code": 0,
  "error": "",
  "metadata": {
    "email": "",
    "name": "",
    "trusted": false
  }
}
```
- make sure you are logged in. Enter `https://0.0.0.0:8414/1.0` in the browser url. You should get back the following payload (as an example, user email and name may change)
```
{
  "type": "sync",
  "status": "Success",
  "status_code": 200,
  "operation": "",
  "error_code": 0,
  "error": "",
  "metadata": {
    "email": "mason.hu@canonical.com",
    "name": "mason.hu@canonical.com",
    "trusted": true
  }
}
```
