### PR TITLE
feat: [WD-13149] Implement Cluster Status Graph Summary

### DIFF
--- a/ui/src/components/DoughnutChart.tsx
+++ b/ui/src/components/DoughnutChart.tsx
@@ -1,0 +1,206 @@
+import { FC, useRef, useState } from "react";
+
+import { Tooltip } from "@canonical/react-components";
+import classNames from "classnames";
+
+type Segment = {
+  /**
+   * The colour of the segment.
+   */
+  color: string;
+  /**
+   * The segment tooltip.
+   */
+  tooltip?: string;
+  /**
+   * The segment length.
+   */
+  value: number;
+};
+
+type Props = {
+  /**
+   * The label in the centre of the doughnut.
+   */
+  label?: string;
+  /**
+   * An optional class name applied to the wrapping element.
+   */
+  className?: string;
+  /**
+   * The width of the segments when hovered.
+   */
+  segmentHoverWidth: number;
+  /**
+   * The width of the segments.
+   */
+  segmentWidth: number;
+  /**
+   * The doughnut segments.
+   */
+  segments: Segment[];
+  /**
+   * The size of the doughnut.
+   */
+  size: number;
+  /**
+   *  ID associated to the specific instance of a Chart.
+   */
+  chartID: string;
+};
+
+export enum TestIds {
+  Label = "label",
+  Segment = "segment",
+}
+
+const DoughnutChart: FC<Props> = ({
+  className,
+  label,
+  segmentHoverWidth,
+  segmentWidth,
+  segments,
+  size,
+  chartID,
+}): JSX.Element => {
+  const [tooltipMessage, setTooltipMessage] = useState<
+    Segment["tooltip"] | null
+  >(null);
+
+  const id = useRef(`doughnut-chart-${chartID}`);
+  const hoverIncrease = segmentHoverWidth - segmentWidth;
+  const adjustedHoverWidth = segmentHoverWidth + hoverIncrease;
+  // The canvas needs enough space so that the hover state does not get cut off.
+  const canvasSize = size + adjustedHoverWidth - segmentWidth;
+  const diameter = size - segmentWidth;
+  const radius = diameter / 2;
+  const circumference = Math.round(diameter * Math.PI);
+  // Calculate the total value of all segments.
+  const total = segments.reduce(
+    (totalValue, segment) => (totalValue += segment.value),
+    0,
+  );
+  let accumulatedLength = 0;
+  const segmentNodes = segments.map(({ color, tooltip, value }, i) => {
+    // The start position is the value of all previous segments.
+    const startPosition = accumulatedLength;
+    // The length of the segment (as a portion of the doughnut circumference)
+    const segmentLength = (value / total) * circumference;
+    // The space left until the end of the circle.
+    const remainingSpace = circumference - (segmentLength + startPosition);
+    // Add this segment length to the running tally.
+    accumulatedLength += segmentLength;
+    return (
+      <circle
+        className="doughnut-chart__segment"
+        cx={radius - segmentWidth / 2 - hoverIncrease}
+        cy={radius + segmentWidth / 2 + hoverIncrease}
+        data-testid={TestIds.Segment}
+        key={i}
+        onMouseOut={
+          tooltip
+            ? () => {
+                // Hide the tooltip.
+                setTooltipMessage(null);
+              }
+            : undefined
+        }
+        onMouseOver={
+          tooltip
+            ? () => {
+                setTooltipMessage(tooltip);
+              }
+            : undefined
+        }
+        r={radius}
+        style={{
+          stroke: color,
+          strokeWidth: segmentWidth,
+          // The dash array used is:
+          // 1 - We want there to be a space before the first visible dash so
+          //     by setting this to 0 we can use the next dash for the space.
+          // 2 - This gap is the distance of all previous segments
+          //     so that the segment starts in the correct spot.
+          // 3 - A dash that is the length of the segment.
+          // 4 - A gap from the end of the segment to the start of the circle
+          //     so that the dash array doesn't repeat and be visible.
+          strokeDasharray: `0 ${startPosition.toFixed(
+            2,
+          )} ${segmentLength.toFixed(2)} ${remainingSpace.toFixed(2)}`,
+        }}
+        // Rotate the segment so that the segments start at the top of
+        // the chart.
+        transform={`rotate(-90 ${radius},${radius})`}
+      />
+    );
+  });
+  return (
+    <div
+      className={classNames("doughnut-chart", className)}
+      style={{ maxWidth: `${canvasSize}px` }}
+    >
+      <Tooltip
+        className="doughnut-chart__tooltip"
+        followMouse={true}
+        message={tooltipMessage}
+        position="right"
+      >
+        <style>
+          {/* Set the hover width of the segments. */}
+          {`#${id.current} .doughnut-chart__segment:hover {
+          stroke-width: ${adjustedHoverWidth} !important;
+        }`}
+        </style>
+        <svg
+          className="doughnut-chart__chart"
+          id={id.current}
+          viewBox={`0 0 ${canvasSize} ${canvasSize}`}
+        >
+          <mask id="myMask">
+            {/* Cover the canvas, this will be the visible area. */}
+            <rect
+              fill="white"
+              height={canvasSize}
+              width={canvasSize}
+              x="0"
+              y="0"
+            />
+            {/* Cut out the center circle so that the hover state doesn't grow inwards. */}
+            <circle
+              cx={canvasSize / 2}
+              cy={canvasSize / 2}
+              fill="black"
+              r={radius - segmentWidth / 2}
+            />
+          </mask>
+          <g mask="url(#myMask)">
+            {/* Force the group to cover the full size of the canvas, otherwise it will only mask the children (in their non-hovered state) */}
+            <rect
+              fill="transparent"
+              height={canvasSize}
+              width={canvasSize}
+              x="0"
+              y="0"
+            />
+            <g>{segmentNodes}</g>
+          </g>
+          {label ? (
+            <text
+              x={radius + adjustedHoverWidth / 2}
+              y={radius + adjustedHoverWidth / 2}
+            >
+              <tspan
+                className="doughnut-chart__label"
+                data-testid={TestIds.Label}
+              >
+                {label}
+              </tspan>
+            </text>
+          ) : null}
+        </svg>
+      </Tooltip>
+    </div>
+  );
+};
+
+export default DoughnutChart;

--- a/ui/src/pages/clusters/AddClusterButton.tsx
+++ b/ui/src/pages/clusters/AddClusterButton.tsx
@@ -11,6 +11,7 @@ const AddClusterButton: FC = () => {
         navigate("/");
       }}
       appearance="positive"
+      className="u-no-margin--bottom"
     >
       Add New Cluster
     </ActionButton>

--- a/ui/src/pages/clusters/ClusterList.tsx
+++ b/ui/src/pages/clusters/ClusterList.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { Row } from "@canonical/react-components";
+import { List, Row } from "@canonical/react-components";
 import BaseLayout from "components/BaseLayout";
 import { useParams } from "react-router-dom";
 import TabLinks from "components/TabLinks";
@@ -7,6 +7,7 @@ import ClusterListTokens from "./ClusterListTokens";
 import ClusterListActive from "./ClusterListActive";
 import ClusterListPending from "./ClusterListPending";
 import AddClusterButton from "./AddClusterButton";
+import ClusterStatusGraph from "./metrics/ClusterStatusGraph";
 
 const ClusterList: FC = () => {
   const { activeTab } = useParams<{
@@ -18,6 +19,10 @@ const ClusterList: FC = () => {
   return (
     <BaseLayout title={"Clusters"} controls={<AddClusterButton />}>
       <Row>
+        <List
+          inline={true}
+          items={[<ClusterStatusGraph key="clusterstatusgraph" />]}
+        />
         <TabLinks tabs={tabs} activeTab={activeTab} tabUrl="/ui/sites" />
         <div>
           {!activeTab && <ClusterListActive />}

--- a/ui/src/pages/clusters/metrics/ClusterStatusGraph.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterStatusGraph.tsx
@@ -1,0 +1,71 @@
+import { Icon } from "@canonical/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { fetchClusters } from "api/clusters";
+import DoughnutChart from "components/DoughnutChart";
+import { FC, ReactNode } from "react";
+import { getMinutesSinceLastHeartbeat } from "util/helpers";
+import { queryKeys } from "util/queryKeys";
+
+const ClusterStatusGraph: FC = () => {
+  const { data: clusters = [] } = useQuery({
+    queryKey: [queryKeys.clusters],
+    queryFn: fetchClusters,
+  });
+
+  const totalClusters = clusters.length;
+  const activeClusters = clusters.filter(
+    (cluster) =>
+      cluster.status == "ACTIVE" && getMinutesSinceLastHeartbeat(cluster) < 5,
+  ).length;
+  const pendingClusters = clusters.filter(
+    (cluster) => cluster.status == "PENDING_APPROVAL",
+  ).length;
+  const degradedClusters = clusters.filter(
+    (cluster) =>
+      cluster.status == "ACTIVE" && getMinutesSinceLastHeartbeat(cluster) > 5,
+  ).length;
+
+  function getPercentageString(portion: number): ReactNode {
+    return (
+      <>
+        <b>{portion}</b> {`(${Math.floor((portion / totalClusters) * 100)}%) `}
+      </>
+    );
+  }
+
+  return (
+    <div className="cluster-status">
+      <DoughnutChart
+        className="cluster-status__chart"
+        chartID="clusterStatus"
+        segmentHoverWidth={45}
+        segmentWidth={40}
+        segments={[
+          { color: "#0E8420", tooltip: "Active", value: activeClusters },
+          { color: "#CC7900", tooltip: "Pending", value: pendingClusters },
+          { color: "#C7162B", tooltip: "Degraded", value: degradedClusters },
+        ]}
+        size={150}
+      />
+      <div className="cluster-status-legend">
+        <div className="u-no-margin p-heading--5">{totalClusters} clusters</div>
+        <div>
+          <Icon name="status-succeeded-small" />
+          {getPercentageString(activeClusters)} Online
+        </div>
+        <div>
+          <Icon name="status-waiting-small" />
+          {getPercentageString(pendingClusters)}
+          Pending
+        </div>
+        <div>
+          <Icon name="status-failed-small" />
+          {getPercentageString(degradedClusters)}
+          Degraded
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ClusterStatusGraph;

--- a/ui/src/sass/_cluster_graphs.scss
+++ b/ui/src/sass/_cluster_graphs.scss
@@ -1,0 +1,15 @@
+$donut-size: 6.5rem;
+
+.cluster-status {
+  display: flex;
+  flex-direction: row;
+  overflow: auto;
+
+  .cluster-status__chart {
+    width: $donut-size;
+  }
+
+  .cluster-status-legend {
+    margin-left: $sph--x-large;
+  }
+}

--- a/ui/src/sass/_doughnut_chart.scss
+++ b/ui/src/sass/_doughnut_chart.scss
@@ -1,0 +1,20 @@
+.doughnut-chart__tooltip {
+  display: block;
+}
+
+.doughnut-chart__tooltip > span {
+  // Override the tooltip wrapper.
+  display: block !important;
+}
+
+.doughnut-chart__chart {
+  // Restrict hover areas to the strokes.
+  pointer-events: stroke;
+}
+
+.doughnut-chart__segment {
+  fill: transparent;
+
+  // Animate stroke size changes on hover.
+  transition: stroke-width 0.3s ease;
+}

--- a/ui/src/sass/styles.scss
+++ b/ui/src/sass/styles.scss
@@ -8,11 +8,14 @@
 @import "meter";
 @import "clustercpu";
 @import "settings_page";
+@import "doughnut_chart";
+@import "cluster_graphs";
 @include custom-p-icon;
 @include vf-p-icon-units;
 @include vf-p-icon-profile;
 @include vf-p-icon-export;
 @include vf-p-icon-status-failed-small;
+@include vf-p-icon-status-waiting-small;
 @include vf-p-icon-status-succeeded-small;
 @include vf-p-icon-switcher-environments;
 @include vf-p-icons;


### PR DESCRIPTION
Work done:
- Implemented Bar chart from Maas with some minor amendments to fit our use case.
- Appropriately destructured the ClusterList Graph Bar and relevant sub-components.
- Added and amended scss.
- Implemented logic to display the percentage breakdowns of active, pending and "degraded" states. More clarification on the appropriate states to include in the doughnut will be useful. Additionally replaced the NanoID dependency with a new ChartID prop for memoization.

![image](https://github.com/user-attachments/assets/797d55ea-c63d-4657-b5a7-7b9f443a6385)

Notes:
- The Doughnut chart component could be upstreamed to React Components.