### PR TITLE
sites: add addresses to status update response [WD-13165]

### DIFF
--- a/internal/api/sites_control.go
+++ b/internal/api/sites_control.go
@@ -124,7 +124,14 @@ func sitesStatusPost(s state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	return response.EmptySyncResponse
+	memberAddresses, err := getSiteManagerAddresses(r.Context(), s)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	return response.SyncResponse(true, types.SiteStatusPostResponse{
+		SiteManagerAddresses: memberAddresses,
+	})
 }
 
 func parseStatusDistribution(statuses []types.StatusDistribution) (int64, string) {

--- a/internal/api/types/site_control.go
+++ b/internal/api/types/site_control.go
@@ -25,3 +25,8 @@ type SiteStatusPost struct {
 	MemberStatuses    []StatusDistribution `json:"member_statuses"`
 	InstanceStatuses  []StatusDistribution `json:"instance_status"`
 }
+
+// SiteStatusPostResponse is sent to LXD in response to a site status update.
+type SiteStatusPostResponse struct {
+	SiteManagerAddresses []string `json:"site_manager_addresses"`
+}

--- a/test/e2e/site_fail_status.go
+++ b/test/e2e/site_fail_status.go
@@ -68,7 +68,7 @@ func testSiteStatusInactiveSite(env *helpers.Environment) (testName string, test
 				helpers.LogTestOutcome(t, condition, err)
 			}
 
-			err = sendStatusUpdate(env, tokenData)
+			_, err = sendStatusUpdate(env, tokenData)
 			if err != nil && err.Error() == "site not found" {
 				err = nil
 			}

--- a/test/e2e/site_success.go
+++ b/test/e2e/site_success.go
@@ -119,8 +119,21 @@ func testSiteSuccess(env *helpers.Environment) (testName string, testFunc func(t
 
 		{
 			condition = "Should be able to receive a status update"
-			err = sendStatusUpdate(env, tokenData)
-			helpers.LogTestOutcome(t, condition, err)
+			actual, err := sendStatusUpdate(env, tokenData)
+			if err != nil {
+				helpers.LogTestOutcome(t, condition, err)
+			}
+
+			expected := types.SiteStatusPostResponse{
+				SiteManagerAddresses: []string{"0.0.0.0:9110"},
+			}
+
+			if !reflect.DeepEqual(*actual, expected) {
+				err = fmt.Errorf("invalid site manager addresses")
+				helpers.LogTestOutcome(t, condition, err)
+			}
+
+			helpers.LogTestOutcome(t, condition, nil)
 		}
 
 		{
@@ -235,28 +248,28 @@ func approveJoinRequest(env *helpers.Environment, siteName string) error {
 }
 
 // sendStatusUpdate sends a status update to the site manager with the correct client certificate.
-func sendStatusUpdate(env *helpers.Environment, tokenData types.ExternalSiteTokenBody) error {
+func sendStatusUpdate(env *helpers.Environment, tokenData types.ExternalSiteTokenBody) (*types.SiteStatusPostResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	clientCert, err := shared.KeyPairAndCA(env.CertDir(), tokenData.ServerName, shared.CertClient, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	clusterCert, err := env.GetClusterCert()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	clusterCertPublicKey, err := clusterCert.PublicKeyX509()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	tlsClient, err := helpers.NewTLSHTTPClient(api.URL{}, clientCert, clusterCertPublicKey)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	input := types.SiteStatusPost{
@@ -278,6 +291,9 @@ func sendStatusUpdate(env *helpers.Environment, tokenData types.ExternalSiteToke
 		},
 	}
 
+	var output types.SiteStatusPostResponse
 	path := api.NewURL().Scheme("https").Host(tokenData.Addresses[0]).Path("1.0", "sites", "status")
-	return tlsClient.Query(ctx, http.MethodPost, path, input, nil, nil)
+	err = tlsClient.Query(ctx, http.MethodPost, path, input, &output, nil)
+
+	return &output, err
 }


### PR DESCRIPTION
## Done
- add site manager addresses to api response for status updates
- adjusted e2e test to assert on site status post response