### PR TITLE
cache: implement caching for site certificates [WD-12924]

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -14,7 +14,7 @@ import (
 	"github.com/canonical/lxd-cluster-manager/internal/state"
 )
 
-func authHandler(clusterManagerState *state.ClusterManagerState) types.AccessHandler {
+func oidcAuthHandler(clusterManagerState *state.ClusterManagerState) types.AccessHandler {
 	return func(clusterState microState.State, r *http.Request) (bool, response.Response) {
 		// always allow unix socket requests
 		if r.RemoteAddr == "@" {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -2,9 +2,12 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/microcluster/client"
 	"github.com/canonical/microcluster/rest/access"
 	microState "github.com/canonical/microcluster/state"
@@ -13,6 +16,8 @@ import (
 	"github.com/canonical/lxd-cluster-manager/internal/oidc"
 	"github.com/canonical/lxd-cluster-manager/internal/state"
 )
+
+const ctxRemoteClusterID request.CtxKey = "remote-cluster-id"
 
 func oidcAuthHandler(clusterManagerState *state.ClusterManagerState) types.AccessHandler {
 	return func(clusterState microState.State, r *http.Request) (bool, response.Response) {
@@ -53,6 +58,44 @@ func oidcAuthHandler(clusterManagerState *state.ClusterManagerState) types.Acces
 		setUserInfoInRequest(result, r)
 
 		return true, resp
+	}
+}
+
+// mtlsAuthHandler is an access handler that checks the client certificate against trusted remote cluster certificates.
+// the client certificate is checked against the trusted certificates in the CertificatesCache which expires every 60 seconds and will be rebuilt with db data.
+// if the client certificate is trusted, the certificate fingerprint and the associated remote cluster ID are set in the request context.
+// this access handler should be used for protected communication between lxd clusters and lxc cluster manager.
+func mtlsAuthHandler(clusterManagerState *state.ClusterManagerState) types.AccessHandler {
+	return func(clusterState microState.State, r *http.Request) (bool, response.Response) {
+		if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+			return false, response.Forbidden(fmt.Errorf("tls is required"))
+		}
+
+		if len(r.TLS.PeerCertificates) != 1 {
+			return false, response.Forbidden(fmt.Errorf("expected exactly one peer certificate"))
+		}
+
+		if clusterManagerState.CertificatesCache.Expired() {
+			err := clusterManagerState.CertificatesCache.RebuildCache(r.Context(), clusterState)
+
+			if err != nil {
+				return false, response.SmartError(err)
+			}
+		}
+
+		peerCert := r.TLS.PeerCertificates[0]
+		trustedCerts := clusterManagerState.CertificatesCache.GetTrustedCerts()
+		trusted, fingerprint := util.CheckMutualTLS(*peerCert, trustedCerts)
+
+		if !trusted {
+			return false, response.Forbidden(fmt.Errorf("invalid cluster certificate"))
+		}
+
+		remoteClusterCert, _ := clusterManagerState.CertificatesCache.GetCertificateEntry(fingerprint)
+		request.SetCtxValue(r, request.CtxUsername, fingerprint)
+		request.SetCtxValue(r, ctxRemoteClusterID, remoteClusterCert.ClusterID)
+
+		return true, nil
 	}
 }
 

--- a/internal/api/api_root.go
+++ b/internal/api/api_root.go
@@ -18,7 +18,7 @@ func apiRootCmd(s *state.ClusterManagerState) rest.Endpoint {
 		Get: rest.EndpointAction{
 			Handler:        apiRootGet,
 			AllowUntrusted: true,
-			AccessHandler:  authHandler(s),
+			AccessHandler:  oidcAuthHandler(s),
 		},
 	}
 }

--- a/internal/api/configuration.go
+++ b/internal/api/configuration.go
@@ -21,7 +21,7 @@ func metadataConfigurationCmd(s *state.ClusterManagerState) rest.Endpoint {
 		Get: rest.EndpointAction{
 			Handler:        metadataConfigurationGet,
 			AllowUntrusted: true,
-			AccessHandler:  authHandler(s),
+			AccessHandler:  oidcAuthHandler(s),
 		},
 	}
 }

--- a/internal/api/manager_configs.go
+++ b/internal/api/manager_configs.go
@@ -27,12 +27,12 @@ var managerConfigsCmd = func(s *state.ClusterManagerState) rest.Endpoint {
 		Patch: rest.EndpointAction{
 			Handler:        managerConfigPatch(s),
 			AllowUntrusted: true,
-			AccessHandler:  authHandler(s),
+			AccessHandler:  oidcAuthHandler(s),
 		},
 		Get: rest.EndpointAction{
 			Handler:        managerConfigsGet,
 			AllowUntrusted: true,
-			AccessHandler:  authHandler(s),
+			AccessHandler:  oidcAuthHandler(s),
 		},
 	}
 }

--- a/internal/api/member_configs.go
+++ b/internal/api/member_configs.go
@@ -30,12 +30,12 @@ func memberConfigCmd(s *state.ClusterManagerState) rest.Endpoint {
 		Patch: rest.EndpointAction{
 			Handler:        memberConfigPatch,
 			AllowUntrusted: true,
-			AccessHandler:  authHandler(s),
+			AccessHandler:  oidcAuthHandler(s),
 		},
 		Get: rest.EndpointAction{
 			Handler:        memberConfigGet,
 			AllowUntrusted: true,
-			AccessHandler:  authHandler(s),
+			AccessHandler:  oidcAuthHandler(s),
 		},
 	}
 }
@@ -46,7 +46,7 @@ func memberConfigsCmd(s *state.ClusterManagerState) rest.Endpoint {
 		Get: rest.EndpointAction{
 			Handler:        memberConfigsGet,
 			AllowUntrusted: true,
-			AccessHandler:  authHandler(s),
+			AccessHandler:  oidcAuthHandler(s),
 		},
 	}
 }

--- a/internal/api/remote_cluster_control.go
+++ b/internal/api/remote_cluster_control.go
@@ -67,17 +67,7 @@ func remoteClustersStatusPost(managerState *state.ClusterManagerState) types.End
 				return fmt.Errorf("remote cluster is pending approval")
 			}
 
-			dbRemoteCluster.CPULoad1 = payload.CPULoad1
-			dbRemoteCluster.CPULoad5 = payload.CPULoad5
-			dbRemoteCluster.CPULoad15 = payload.CPULoad15
-			dbRemoteCluster.CPUTotalCount = payload.CPUTotalCount
-			dbRemoteCluster.DiskTotalSize = payload.DiskTotalSize
-			dbRemoteCluster.DiskUsage = payload.DiskUsage
-			dbRemoteCluster.InstanceCount, dbRemoteCluster.InstanceStatuses = parseStatusDistribution(payload.InstanceStatuses)
-			dbRemoteCluster.MemberCount, dbRemoteCluster.MemberStatuses = parseStatusDistribution(payload.MemberStatuses)
-			dbRemoteCluster.MemoryTotalAmount = payload.MemoryTotalAmount
-			dbRemoteCluster.MemoryUsage = payload.MemoryUsage
-			dbRemoteCluster.UpdatedAt = time.Now()
+			dbRemoteCluster.Put(payload)
 
 			err = database.UpdateRemoteClusterDetail(ctx, tx, remoteClusterID, *dbRemoteCluster)
 			if err != nil {
@@ -101,24 +91,6 @@ func remoteClustersStatusPost(managerState *state.ClusterManagerState) types.End
 			ClusterManagerAddresses: memberAddresses,
 		})
 	}
-}
-
-func parseStatusDistribution(statuses []types.StatusDistribution) (int64, string) {
-	if len(statuses) == 0 {
-		return 0, "[]"
-	}
-
-	parsedStatuses, err := json.Marshal(statuses)
-	if err != nil {
-		return 0, "[]"
-	}
-
-	var total int64
-	for _, s := range statuses {
-		total += s.Count
-	}
-
-	return total, string(parsedStatuses)
 }
 
 func remoteClustersPost(managerState *state.ClusterManagerState) types.EndpointHandler {

--- a/internal/api/remote_cluster_control.go
+++ b/internal/api/remote_cluster_control.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -12,126 +11,96 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microcluster/rest"
 	microTypes "github.com/canonical/microcluster/rest/types"
-	"github.com/canonical/microcluster/state"
+	microState "github.com/canonical/microcluster/state"
 
 	"github.com/canonical/lxd-cluster-manager/internal/api/types"
 	"github.com/canonical/lxd-cluster-manager/internal/database"
+	"github.com/canonical/lxd-cluster-manager/internal/state"
 )
 
-var remoteClustersControlCmd = rest.Endpoint{
-	Path: "remote-clusters",
-	Post: rest.EndpointAction{Handler: remoteClustersPost, AllowUntrusted: true},
+func remoteClustersControlCmd(s *state.ClusterManagerState) rest.Endpoint {
+	return rest.Endpoint{
+		Path: "remote-clusters",
+		Post: rest.EndpointAction{
+			Handler:        remoteClustersPost(s),
+			AllowUntrusted: true,
+		},
+	}
 }
 
-var remoteClustersStatusCmd = rest.Endpoint{
-	Path: "remote-clusters/status",
-	Post: rest.EndpointAction{Handler: remoteClustersStatusPost, AllowUntrusted: true},
+func remoteClustersStatusCmd(s *state.ClusterManagerState) rest.Endpoint {
+	return rest.Endpoint{
+		Path: "remote-clusters/status",
+		Post: rest.EndpointAction{
+			Handler:        remoteClustersStatusPost(s),
+			AllowUntrusted: true,
+			AccessHandler:  mtlsAuthHandler(s),
+		},
+	}
 }
 
-func remoteClustersStatusPost(s state.State, r *http.Request) response.Response {
-	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
-		logger.Warn("tls is required")
-		return response.BadRequest(fmt.Errorf("tls is required"))
-	}
-
-	if len(r.TLS.PeerCertificates) != 1 {
-		logger.Warn("Expected exactly one peer certificate")
-		return response.BadRequest(fmt.Errorf("expected exactly one peer certificate"))
-	}
-	peerCert := r.TLS.PeerCertificates[0]
-
-	var remoteClusterID int64
-	err := s.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		dbRemoteClusters, err := database.GetCoreRemoteClustersWithDetails(ctx, tx)
+func remoteClustersStatusPost(managerState *state.ClusterManagerState) types.EndpointHandler {
+	return func(clusterState microState.State, r *http.Request) response.Response {
+		payload := types.RemoteClusterStatusPost{}
+		err := json.NewDecoder(r.Body).Decode(&payload)
 		if err != nil {
-			return err
+			return response.BadRequest(err)
 		}
 
-		for _, dbRemoteCluster := range dbRemoteClusters {
-			if dbRemoteCluster.Status == string(types.PENDING_APPROVAL) {
-				continue
-			}
+		remoteClusterID, err := request.GetCtxValue[int64](r.Context(), ctxRemoteClusterID)
+		if err != nil {
+			return response.SmartError(err)
+		}
 
-			dbRemoteClusterCert, err := microTypes.ParseX509Certificate(dbRemoteCluster.ClusterCertificate)
+		err = clusterState.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+			dbRemoteCluster, err := database.GetRemoteClusterDetail(ctx, tx, remoteClusterID)
 			if err != nil {
-				logger.Warn("Failed to parse remoteCluster certificate", logger.Ctx{"remoteCluster": dbRemoteCluster.Name, "err": err})
-				continue
+				return err
 			}
 
-			if dbRemoteClusterCert.Certificate.NotAfter.Before(time.Now()) {
-				logger.Warn("RemoteCluster certificate is expired", logger.Ctx{"remoteCluster": dbRemoteCluster.Name})
-				continue
+			if dbRemoteCluster.Status == string(types.PENDING_APPROVAL) {
+				return fmt.Errorf("remote cluster is pending approval")
 			}
 
-			// check if public key of dbRemoteCluster matches the peer certificate from the request
-			if bytes.Equal(dbRemoteClusterCert.Raw, peerCert.Raw) {
-				remoteClusterID = dbRemoteCluster.ID
-				break
+			dbRemoteCluster.CPULoad1 = payload.CPULoad1
+			dbRemoteCluster.CPULoad5 = payload.CPULoad5
+			dbRemoteCluster.CPULoad15 = payload.CPULoad15
+			dbRemoteCluster.CPUTotalCount = payload.CPUTotalCount
+			dbRemoteCluster.DiskTotalSize = payload.DiskTotalSize
+			dbRemoteCluster.DiskUsage = payload.DiskUsage
+			dbRemoteCluster.InstanceCount, dbRemoteCluster.InstanceStatuses = parseStatusDistribution(payload.InstanceStatuses)
+			dbRemoteCluster.MemberCount, dbRemoteCluster.MemberStatuses = parseStatusDistribution(payload.MemberStatuses)
+			dbRemoteCluster.MemoryTotalAmount = payload.MemoryTotalAmount
+			dbRemoteCluster.MemoryUsage = payload.MemoryUsage
+			dbRemoteCluster.UpdatedAt = time.Now()
+
+			err = database.UpdateRemoteClusterDetail(ctx, tx, remoteClusterID, *dbRemoteCluster)
+			if err != nil {
+				return err
 			}
-		}
 
-		return nil
-	})
+			return nil
+		})
 
-	if err != nil {
-		logger.Warn("Failed to get remoteCluster ID", logger.Ctx{"err": err})
-		return response.SmartError(err)
-	}
-
-	if remoteClusterID == 0 {
-		logger.Warn("cluster not found")
-		return response.NotFound(fmt.Errorf("cluster not found"))
-	}
-
-	payload := types.RemoteClusterStatusPost{}
-	err = json.NewDecoder(r.Body).Decode(&payload)
-	if err != nil {
-		return response.BadRequest(err)
-	}
-
-	err = s.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		dbRemoteCluster, err := database.GetRemoteClusterDetail(ctx, tx, remoteClusterID)
 		if err != nil {
-			return err
+			logger.Warn("Failed to update remote cluster status", logger.Ctx{"remote cluster": remoteClusterID, "err": err})
+			return response.SmartError(err)
 		}
 
-		dbRemoteCluster.CPULoad1 = payload.CPULoad1
-		dbRemoteCluster.CPULoad5 = payload.CPULoad5
-		dbRemoteCluster.CPULoad15 = payload.CPULoad15
-		dbRemoteCluster.CPUTotalCount = payload.CPUTotalCount
-		dbRemoteCluster.DiskTotalSize = payload.DiskTotalSize
-		dbRemoteCluster.DiskUsage = payload.DiskUsage
-		dbRemoteCluster.InstanceCount, dbRemoteCluster.InstanceStatuses = parseStatusDistribution(payload.InstanceStatuses)
-		dbRemoteCluster.MemberCount, dbRemoteCluster.MemberStatuses = parseStatusDistribution(payload.MemberStatuses)
-		dbRemoteCluster.MemoryTotalAmount = payload.MemoryTotalAmount
-		dbRemoteCluster.MemoryUsage = payload.MemoryUsage
-		dbRemoteCluster.UpdatedAt = time.Now()
-
-		err = database.UpdateRemoteClusterDetail(ctx, tx, remoteClusterID, *dbRemoteCluster)
+		memberAddresses, err := getClusterManagerAddresses(r.Context(), clusterState)
 		if err != nil {
-			return err
+			return response.InternalError(err)
 		}
 
-		return nil
-	})
-
-	if err != nil {
-		logger.Warn("Failed to update remoteCluster status", logger.Ctx{"remoteCluster": remoteClusterID, "err": err})
-		return response.SmartError(err)
+		return response.SyncResponse(true, types.RemoteClusterStatusPostResponse{
+			ClusterManagerAddresses: memberAddresses,
+		})
 	}
-
-	memberAddresses, err := getClusterManagerAddresses(r.Context(), s)
-	if err != nil {
-		return response.InternalError(err)
-	}
-
-	return response.SyncResponse(true, types.RemoteClusterStatusPostResponse{
-		ClusterManagerAddresses: memberAddresses,
-	})
 }
 
 func parseStatusDistribution(statuses []types.StatusDistribution) (int64, string) {
@@ -152,83 +121,97 @@ func parseStatusDistribution(statuses []types.StatusDistribution) (int64, string
 	return total, string(parsedStatuses)
 }
 
-func remoteClustersPost(s state.State, r *http.Request) response.Response {
-	payload := types.RemoteClusterPost{}
+func remoteClustersPost(managerState *state.ClusterManagerState) types.EndpointHandler {
+	return func(clusterState microState.State, r *http.Request) response.Response {
+		payload := types.RemoteClusterPost{}
 
-	err := json.NewDecoder(r.Body).Decode(&payload)
-	if err != nil {
-		return response.BadRequest(err)
-	}
-
-	if payload.ClusterName == "" {
-		return response.BadRequest(fmt.Errorf("remoteCluster name is required"))
-	}
-
-	if payload.ClusterCertificate == "" {
-		return response.BadRequest(fmt.Errorf("remoteCluster certificate is required"))
-	}
-
-	// get token secret for HMAC verification
-	var token *database.CoreRemoteClusterToken
-	err = s.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		var err error
-		token, err = database.GetCoreRemoteClusterToken(ctx, tx, payload.ClusterName)
+		err := json.NewDecoder(r.Body).Decode(&payload)
 		if err != nil {
-			return err
+			return response.BadRequest(err)
 		}
 
-		return nil
-	})
+		if payload.ClusterName == "" {
+			return response.BadRequest(fmt.Errorf("remote cluster name is required"))
+		}
 
-	if err != nil {
-		return response.SmartError(err)
-	}
+		if payload.ClusterCertificate == "" {
+			return response.BadRequest(fmt.Errorf("remote cluster certificate is required"))
+		}
 
-	// check if token has expired
-	if time.Now().After(token.Expiry) {
-		return response.Forbidden(fmt.Errorf("token has expired"))
-	}
+		cert, err := microTypes.ParseX509Certificate(payload.ClusterCertificate)
+		if err != nil {
+			return response.BadRequest(fmt.Errorf("invalid certificate: %v", err))
+		}
 
-	// verify HMAC
-	hmacOK, err := verifyHMAC(payload, r, token.Secret)
-	if err != nil || !hmacOK {
-		return response.Forbidden(err)
-	}
+		// get token secret for HMAC verification
+		var token *database.CoreRemoteClusterToken
+		err = clusterState.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+			var err error
+			token, err = database.GetCoreRemoteClusterToken(ctx, tx, payload.ClusterName)
+			if err != nil {
+				return err
+			}
 
-	// Create remoteCluster entry and delete token in a single db transaction
-	err = s.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		// create remoteCluster entry
-		remoteClusterID, err := database.CreateCoreRemoteCluster(ctx, tx, database.CoreRemoteCluster{
-			Name:               payload.ClusterName,
-			ClusterCertificate: payload.ClusterCertificate,
+			return nil
 		})
 
 		if err != nil {
-			return err
+			return response.SmartError(err)
 		}
 
-		// create relevant remoteCluster details
-		_, err = database.CreateRemoteClusterDetail(ctx, tx, database.RemoteClusterDetail{
-			Status:              string(types.PENDING_APPROVAL),
-			CoreRemoteClusterID: remoteClusterID,
-			JoinedAt:            time.Now(),
-			MemberStatuses:      "[]",
-			InstanceStatuses:    "[]",
+		// check if token has expired
+		if time.Now().After(token.Expiry) {
+			return response.Forbidden(fmt.Errorf("token has expired"))
+		}
+
+		// verify HMAC
+		hmacOK, err := verifyHMAC(payload, r, token.Secret)
+		if err != nil || !hmacOK {
+			return response.Forbidden(err)
+		}
+
+		// Create remote cluster entry and delete token in a single db transaction
+		var remoteClusterID int64
+		err = clusterState.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+			var err error
+			// create remote cluster entry
+			remoteClusterID, err = database.CreateCoreRemoteCluster(ctx, tx, database.CoreRemoteCluster{
+				Name:               payload.ClusterName,
+				ClusterCertificate: payload.ClusterCertificate,
+			})
+
+			if err != nil {
+				return err
+			}
+
+			// create relevant remote cluster details
+			_, err = database.CreateRemoteClusterDetail(ctx, tx, database.RemoteClusterDetail{
+				Status:              string(types.PENDING_APPROVAL),
+				CoreRemoteClusterID: remoteClusterID,
+				JoinedAt:            time.Now(),
+				MemberStatuses:      "[]",
+				InstanceStatuses:    "[]",
+			})
+
+			if err != nil {
+				return err
+			}
+
+			// delete remote cluster token
+			return database.DeleteCoreRemoteClusterToken(ctx, tx, payload.ClusterName)
 		})
 
 		if err != nil {
-			return err
+			return response.SmartError(err)
 		}
 
-		// delete remoteCluster token
-		return database.DeleteCoreRemoteClusterToken(ctx, tx, payload.ClusterName)
-	})
+		err = managerState.CertificatesCache.AddCertificate(cert.Certificate, remoteClusterID)
+		if err != nil {
+			return response.InternalError(err)
+		}
 
-	if err != nil {
-		return response.SmartError(err)
+		return response.EmptySyncResponse
 	}
-
-	return response.EmptySyncResponse
 }
 
 func verifyHMAC(payload types.RemoteClusterPost, r *http.Request, secret string) (bool, error) {

--- a/internal/api/remote_cluster_join_tokens.go
+++ b/internal/api/remote_cluster_join_tokens.go
@@ -26,7 +26,7 @@ func remoteClusterJoinTokensCmd(s *state.ClusterManagerState) rest.Endpoint {
 		Post: rest.EndpointAction{
 			Handler:        tokenPost,
 			AllowUntrusted: true,
-			AccessHandler:  authHandler(s),
+			AccessHandler:  oidcAuthHandler(s),
 		},
 		Get: rest.EndpointAction{Handler: tokenGet, AllowUntrusted: true},
 	}
@@ -38,7 +38,7 @@ func remoteClusterJoinTokenCmd(s *state.ClusterManagerState) rest.Endpoint {
 		Delete: rest.EndpointAction{
 			Handler:        tokenDelete,
 			AllowUntrusted: true,
-			AccessHandler:  authHandler(s),
+			AccessHandler:  oidcAuthHandler(s),
 		},
 	}
 }

--- a/internal/api/remote_cluster_management.go
+++ b/internal/api/remote_cluster_management.go
@@ -25,7 +25,7 @@ func remoteClustersCmd(s *state.ClusterManagerState) rest.Endpoint {
 		Get: rest.EndpointAction{
 			Handler:        remoteClustersGet,
 			AllowUntrusted: true,
-			AccessHandler:  authHandler(s),
+			AccessHandler:  oidcAuthHandler(s),
 		},
 	}
 }
@@ -36,17 +36,17 @@ func remoteClusterCmd(s *state.ClusterManagerState) rest.Endpoint {
 		Get: rest.EndpointAction{
 			Handler:        remoteClusterGet,
 			AllowUntrusted: true,
-			AccessHandler:  authHandler(s),
+			AccessHandler:  oidcAuthHandler(s),
 		},
 		Delete: rest.EndpointAction{
 			Handler:        remoteClusterDelete,
 			AllowUntrusted: true,
-			AccessHandler:  authHandler(s),
+			AccessHandler:  oidcAuthHandler(s),
 		},
 		Patch: rest.EndpointAction{
 			Handler:        remoteClusterPatch,
 			AllowUntrusted: true,
-			AccessHandler:  authHandler(s),
+			AccessHandler:  oidcAuthHandler(s),
 		},
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -52,25 +52,27 @@ func remoteClusterManagementListener(s *state.ClusterManagerState) rest.Server {
 	}
 }
 
-var remoteClusterControlListener = rest.Server{
-	CoreAPI:   false,
-	PreInit:   false,
-	ServeUnix: false,
-	Resources: []rest.Resources{
-		{
-			PathPrefix: types.APIVersionPrefix,
-			Endpoints: []rest.Endpoint{
-				remoteClustersControlCmd,
-				remoteClustersStatusCmd,
+func remoteClusterControlListener(s *state.ClusterManagerState) rest.Server {
+	return rest.Server{
+		CoreAPI:   false,
+		PreInit:   false,
+		ServeUnix: false,
+		Resources: []rest.Resources{
+			{
+				PathPrefix: types.APIVersionPrefix,
+				Endpoints: []rest.Endpoint{
+					remoteClustersControlCmd(s),
+					remoteClustersStatusCmd(s),
+				},
 			},
 		},
-	},
+	}
 }
 
 // GetServers returns all the network listeners for Cluster Manager.
 func GetServers(s *state.ClusterManagerState) map[string]rest.Server {
 	return map[string]rest.Server{
 		string(ManagementListener): remoteClusterManagementListener(s),
-		string(ControlListener):    remoteClusterControlListener,
+		string(ControlListener):    remoteClusterControlListener(s),
 	}
 }

--- a/internal/database/remote_cluster_details.go
+++ b/internal/database/remote_cluster_details.go
@@ -1,7 +1,10 @@
 package database
 
 import (
+	"encoding/json"
 	"time"
+
+	"github.com/canonical/lxd-cluster-manager/internal/api/types"
 )
 
 //go:generate -command mapper lxd-generate db mapper -t remote_cluster_details.mapper.go
@@ -41,7 +44,40 @@ type RemoteClusterDetail struct {
 	UpdatedAt           time.Time
 }
 
+// Put updates the RemoteClusterDetail with the provided payload.
+func (r *RemoteClusterDetail) Put(payload types.RemoteClusterStatusPost) {
+	r.CPULoad1 = payload.CPULoad1
+	r.CPULoad5 = payload.CPULoad5
+	r.CPULoad15 = payload.CPULoad15
+	r.CPUTotalCount = payload.CPUTotalCount
+	r.DiskTotalSize = payload.DiskTotalSize
+	r.DiskUsage = payload.DiskUsage
+	r.InstanceCount, r.InstanceStatuses = parseStatusDistribution(payload.InstanceStatuses)
+	r.MemberCount, r.MemberStatuses = parseStatusDistribution(payload.MemberStatuses)
+	r.MemoryTotalAmount = payload.MemoryTotalAmount
+	r.MemoryUsage = payload.MemoryUsage
+	r.UpdatedAt = time.Now()
+}
+
 // RemoteClusterDetailFilter is a required struct for use with lxd-generate. It is used for filtering fields on database fetches.
 type RemoteClusterDetailFilter struct {
 	CoreRemoteClusterID *int64
+}
+
+func parseStatusDistribution(statuses []types.StatusDistribution) (int64, string) {
+	if len(statuses) == 0 {
+		return 0, "[]"
+	}
+
+	parsedStatuses, err := json.Marshal(statuses)
+	if err != nil {
+		return 0, "[]"
+	}
+
+	var total int64
+	for _, s := range statuses {
+		total += s.Count
+	}
+
+	return total, string(parsedStatuses)
 }

--- a/internal/state/cert_cache.go
+++ b/internal/state/cert_cache.go
@@ -1,0 +1,117 @@
+package state
+
+import (
+	"context"
+	"crypto/x509"
+	"database/sql"
+	"sync"
+	"time"
+
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/microcluster/rest/types"
+	"github.com/canonical/microcluster/state"
+
+	"github.com/canonical/lxd-cluster-manager/internal/database"
+)
+
+// CertificateCacheEntry represents a cache entry mapped to a certificate fingerprint.
+type CertificateCacheEntry struct {
+	ClusterID   int64
+	Certificate *x509.Certificate
+}
+
+// CertificatesCache represent a cache of LXD cluster certificates with a TTL.
+type CertificatesCache struct {
+	Certificates map[string]*CertificateCacheEntry
+	// TTL is the time when the cache will expire.
+	// The cache TTL is used to eliminate the need to synchronize the cache across all members of the cluster.
+	// The cache will be re-built using db data after TTL is reached
+	TTL time.Time
+	mu  sync.RWMutex
+}
+
+// AddCertificate adds a certificate entry to the cache.
+func (c *CertificatesCache) AddCertificate(cert *x509.Certificate, clusterID int64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	fingerprint := shared.CertFingerprint(cert)
+
+	c.Certificates[fingerprint] = &CertificateCacheEntry{
+		ClusterID:   clusterID,
+		Certificate: cert,
+	}
+
+	return nil
+}
+
+// Expired returns true if the cache has expired.
+// No need to lock the cache here since TTL will not change concurrently after cache is created.
+func (c *CertificatesCache) Expired() bool {
+	return time.Now().After(c.TTL)
+}
+
+// GetCertificateEntry returns the cluster ID associated with a certificate fingerprint.
+func (c *CertificatesCache) GetCertificateEntry(fingerprint string) (CertificateCacheEntry, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, ok := c.Certificates[fingerprint]
+	if !ok || entry == nil {
+		return CertificateCacheEntry{}, false
+	}
+
+	return *entry, true
+}
+
+// GetTrustedCerts returns a map of trusted certificates keyed by their fingerprint.
+func (c *CertificatesCache) GetTrustedCerts() map[string]x509.Certificate {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	trustedCerts := make(map[string]x509.Certificate)
+	for fingerprint, entry := range c.Certificates {
+		trustedCerts[fingerprint] = *entry.Certificate
+	}
+
+	return trustedCerts
+}
+
+// RebuildCache rebuilds the cache from the database.
+func (c *CertificatesCache) RebuildCache(ctx context.Context, clutserState state.State) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return clutserState.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		var dbRemoteClusters []database.CoreRemoteClusterWithDetail
+		var err error
+
+		dbRemoteClusters, err = database.GetCoreRemoteClustersWithDetails(ctx, tx)
+		if err != nil {
+			return err
+		}
+
+		newCacheEntries := make(map[string]*CertificateCacheEntry)
+		for _, dbRemoteCluster := range dbRemoteClusters {
+			clusterCert, err := types.ParseX509Certificate(dbRemoteCluster.ClusterCertificate)
+			if err != nil {
+				logger.Warn("Failed to parse remote cluster certificate", logger.Ctx{"remoteCluster": dbRemoteCluster.Name, "err": err})
+				continue
+			}
+
+			cacheEntry := &CertificateCacheEntry{
+				ClusterID:   dbRemoteCluster.ID,
+				Certificate: clusterCert.Certificate,
+			}
+
+			clusterCertFingerprint := shared.CertFingerprint(clusterCert.Certificate)
+			newCacheEntries[clusterCertFingerprint] = cacheEntry
+		}
+
+		c.Certificates = newCacheEntries
+		c.TTL = time.Now().Add(60 * time.Second)
+
+		return nil
+	})
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"sync"
+	"time"
 
 	"github.com/canonical/microcluster/microcluster"
 
@@ -12,12 +13,19 @@ import (
 type ClusterManagerState struct {
 	// OIDCVerifier is the OpenID Connect verifier used for user authentication and validate authentication for protected API endpoints.
 	OIDCVerifier *oidc.Verifier
-	mu           sync.RWMutex
+	// CertificateCache is a map of certificate fingerprints to remote cluster certificates.
+	CertificatesCache *CertificatesCache
+	mu                sync.RWMutex
 }
 
 // New creates a new ClusterManagerState.
 func New(m *microcluster.MicroCluster) *ClusterManagerState {
-	return &ClusterManagerState{}
+	return &ClusterManagerState{
+		CertificatesCache: &CertificatesCache{
+			Certificates: make(map[string]*CertificateCacheEntry),
+			TTL:          time.Now().Add(60 * time.Second),
+		},
+	}
 }
 
 // SetOIDCVerifier sets the OIDCVerifier.

--- a/test/e2e/remote_cluster_fail_status.go
+++ b/test/e2e/remote_cluster_fail_status.go
@@ -69,7 +69,7 @@ func testRemoteClusterStatusInactive(env *helpers.Environment) (testName string,
 			}
 
 			_, err = sendStatusUpdate(env, tokenData)
-			if err != nil && err.Error() == "cluster not found" {
+			if err != nil && err.Error() == "remote cluster is pending approval" {
 				err = nil
 			}
 
@@ -102,7 +102,7 @@ func testRemoteClusterStatusInvalidCert(env *helpers.Environment) (testName stri
 			}
 
 			err = sendStatusUpdateInvalidCert(env, tokenData)
-			if err != nil && err.Error() == "cluster not found" {
+			if err != nil && err.Error() == "invalid cluster certificate" {
 				err = nil
 			}
 


### PR DESCRIPTION
## Done
- added a certificates cache to manager daemon state
- the certificates cache will be invalidated after 60 seconds, and will be rebuilt during the very next status update from lxd
- the cache is used for mtls authentication for the control listener status endpoint