### PR TITLE
Add UI e2e tests [WD-13243]

### DIFF
--- a/internal/api/types/server.go
+++ b/internal/api/types/server.go
@@ -7,6 +7,6 @@ const (
 	APIVersionPrefix types.EndpointPrefix = "1.0"
 	// NoPrefix is the path prefix for any endpoints that should be located at server root.
 	NoPrefix types.EndpointPrefix = ""
-	// InternalEndpoint is restricted to trusted servers.
-	InternalEndpoint types.EndpointPrefix = "cluster/internal"
+	// InternalPublicEndpoint is restricted to trusted servers.
+	InternalPublicEndpoint types.EndpointPrefix = "core/1.0"
 )

--- a/internal/client/daemon.go
+++ b/internal/client/daemon.go
@@ -19,7 +19,7 @@ func GetDaemonServerConfigs(ctx context.Context, c *client.Client) (map[string]a
 
 	var serverConfigs map[string]apiTypes.ServerConfig
 	endpoint := api.NewURL().Path("daemon", "servers")
-	err := c.Query(queryCtx, "GET", types.InternalEndpoint, endpoint, nil, &serverConfigs)
+	err := c.Query(queryCtx, "GET", types.InternalPublicEndpoint, endpoint, nil, &serverConfigs)
 	if err != nil {
 		clientURL := c.URL()
 		return nil, fmt.Errorf("Failed performing action on %q: %w", clientURL.String(), err)

--- a/ui/tests/cluster-list.spec.ts
+++ b/ui/tests/cluster-list.spec.ts
@@ -1,6 +1,0 @@
-import { expect, test } from "@playwright/test";
-
-test("cluster list", async ({ page }) => {
-  await page.goto("/ui/clusters");
-  expect(await page.title()).toBe("LXD Cluster Manager");
-});

--- a/ui/tests/helpers/name.ts
+++ b/ui/tests/helpers/name.ts
@@ -1,0 +1,3 @@
+export const randomNameSuffix = () => {
+  return (Math.random() + 1).toString(36).substring(7);
+};

--- a/ui/tests/helpers/remote-cluster-tokens.ts
+++ b/ui/tests/helpers/remote-cluster-tokens.ts
@@ -1,0 +1,34 @@
+import { Page, expect } from "@playwright/test";
+
+export const createRemoteClusterToken = async (
+  page: Page,
+  clusterName: string,
+) => {
+  await page.goto("/ui");
+  await page.getByRole("button", { name: "Add New Cluster" }).click();
+  await page.getByPlaceholder("Enter Name").click();
+  await page.getByPlaceholder("Enter Name").fill(clusterName);
+  await page.getByRole("button", { name: "Create" }).click();
+  await expect(page.getByTestId("notification-title")).toContainText(
+    "The token has been created and will be displayed only once. Please save it now:",
+  );
+};
+
+export const revokeRemoteClusterToken = async (
+  page: Page,
+  clusterName: string,
+) => {
+  await page.goto("/ui");
+  await page.getByTestId("tab-link-Tokens").click();
+  await page
+    .getByRole("row", { name: clusterName })
+    .getByRole("button")
+    .click();
+  await page
+    .getByRole("dialog", { name: "Confirm revoke" })
+    .getByRole("button", { name: "Revoke" })
+    .click();
+  await page.waitForSelector(
+    `text=Successfully revoked token for cluster ${clusterName}.`,
+  );
+};

--- a/ui/tests/helpers/remote-clusters.ts
+++ b/ui/tests/helpers/remote-clusters.ts
@@ -1,0 +1,123 @@
+import { Page, expect } from "@playwright/test";
+import { randomNameSuffix } from "./name";
+
+export const randomClusterName = (): string => {
+  return `playwright-token-${randomNameSuffix()}`;
+};
+
+export const getClusterCountByStatus = async (
+  page: Page,
+  status: "Online" | "Pending" | "Degraded",
+) => {
+  const clusterStatusPending = page
+    .getByRole("listitem")
+    .filter({ hasText: "Degraded" })
+    .getByText(status);
+
+  return parseInt(
+    (await clusterStatusPending.textContent())?.split(" ")[0] || "",
+  );
+};
+
+export const approvePendingCluster = async (page: Page): Promise<string> => {
+  await page.goto("/ui");
+  await page.getByTestId("tab-link-Pending").click();
+  // Since we can create a new pending cluster in the UI, we can't target a specific cluster
+  // this test currently relies on dummy data.
+  const firstPendingCluster = page
+    .getByRole("row", { name: "Approve" })
+    .first();
+  const clusterNameCell = firstPendingCluster.getByRole("gridcell").first();
+  const clusterName = await clusterNameCell.innerText();
+
+  const numPendingClustersBefore = await getClusterCountByStatus(
+    page,
+    "Pending",
+  );
+
+  await firstPendingCluster.getByRole("button", { name: "Approve" }).click();
+  await page.waitForSelector(
+    `text=Successfully approved cluster ${clusterName}.`,
+  );
+
+  const numPendingClustersAfter = await getClusterCountByStatus(
+    page,
+    "Pending",
+  );
+
+  expect(numPendingClustersAfter).toBeLessThan(numPendingClustersBefore);
+
+  return clusterName;
+};
+
+export const checkClusterExistInTable = async (
+  page: Page,
+  clusterName: string,
+  table: "Active" | "Pending",
+): Promise<boolean> => {
+  await page.goto("/ui");
+  await page.getByTestId(`tab-link-${table}`).click();
+
+  const tablePagination = page.getByLabel("Table pagination control");
+  const nextPageButton = tablePagination.getByRole("button", {
+    name: "Next page",
+  });
+
+  const clusterNameCell = page
+    .getByRole("row", { name: clusterName })
+    .getByRole("gridcell", { name: clusterName, exact: true });
+
+  let clusterExists = await clusterNameCell.isVisible();
+  if (clusterExists) {
+    return true;
+  }
+
+  // iterage table pagination and try to find the cluster
+  let isEndOfPages = await nextPageButton.isDisabled();
+  while (!isEndOfPages) {
+    await nextPageButton.click();
+    clusterExists = await clusterNameCell.isVisible();
+    if (clusterExists) {
+      return true;
+    }
+    isEndOfPages = await nextPageButton.isDisabled();
+  }
+
+  return false;
+};
+
+export const deletePendingCluster = async (page: Page): Promise<string> => {
+  await page.goto("/ui");
+  await page.getByTestId("tab-link-Pending").click();
+  // Since we can create a new pending cluster in the UI, we can't target a specific cluster
+  // this test currently relies on dummy data.
+  const firstPendingCluster = page
+    .getByRole("row", { name: "Approve" })
+    .first();
+  const clusterNameCell = firstPendingCluster.getByRole("gridcell").first();
+  const clusterName = await clusterNameCell.innerText();
+
+  const numPendingClustersBefore = await getClusterCountByStatus(
+    page,
+    "Pending",
+  );
+
+  await firstPendingCluster.getByRole("button", { name: "Delete" }).click();
+  await page
+    .getByRole("dialog", { name: "Confirm delete" })
+    .getByRole("button", { name: "Delete" })
+    .click();
+
+  await page.waitForSelector(
+    `text=Successfully deleted cluster ${clusterName}.`,
+  );
+
+  const numPendingClustersAfter = await getClusterCountByStatus(
+    page,
+    "Pending",
+  );
+
+  expect(numPendingClustersAfter).toBeLessThan(numPendingClustersBefore);
+
+  return clusterName;
+};

--- a/ui/tests/helpers/settings.ts
+++ b/ui/tests/helpers/settings.ts
@@ -1,0 +1,58 @@
+import { Locator, Page, expect } from "@playwright/test";
+import { randomNameSuffix } from "./name";
+
+export const randomClusterName = (): string => {
+  return `playwright-token-${randomNameSuffix()}`;
+};
+
+export const goToSettingsPage = async (page: Page) => {
+  await page.goto("/ui");
+  await page.getByRole("link", { name: "Settings" }).click();
+  await page.waitForSelector("text=Settings");
+};
+
+export const validateSettingValue = async (
+  settingRow: Locator,
+  value: string,
+) => {
+  const readModeValue = settingRow.locator(".readmode-value");
+  await expect(readModeValue).toHaveText(value);
+};
+
+export const updateManagerSetting = async (
+  page: Page,
+  settingName: string,
+  content: string,
+): Promise<Locator> => {
+  const settingRow = page.locator("css=tr", { hasText: settingName });
+  await settingRow.getByRole("button").click();
+
+  const settingInput = settingRow.getByRole("textbox");
+  await settingInput.fill(content);
+  await settingRow.getByRole("button", { name: "Save", exact: true }).click();
+  await page.waitForSelector(`text=Setting ${settingName} updated.`);
+  await page.getByRole("button", { name: "Close notification" }).click();
+  return settingRow;
+};
+
+export const updateMemberSetting = async (
+  page: Page,
+  member: string,
+  settingName: string,
+  content: string,
+): Promise<Locator> => {
+  const memberSettingRow = page
+    .getByRole("row")
+    .filter({ hasText: `${member}.${settingName}` });
+  await memberSettingRow.getByRole("button").click();
+
+  const settingInput = memberSettingRow.getByRole("textbox");
+  await settingInput.fill(content);
+  await memberSettingRow
+    .getByRole("button", { name: "Save", exact: true })
+    .click();
+  await page.waitForSelector(`text=Setting ${settingName} updated.`);
+  await page.getByRole("button", { name: "Close notification" }).click();
+
+  return memberSettingRow;
+};

--- a/ui/tests/remote-cluster-tokens.spec.ts
+++ b/ui/tests/remote-cluster-tokens.spec.ts
@@ -1,0 +1,12 @@
+import { test } from "@playwright/test";
+import {
+  createRemoteClusterToken,
+  revokeRemoteClusterToken,
+} from "./helpers/remote-cluster-tokens";
+import { randomClusterName } from "./helpers/remote-clusters";
+
+test("create and revoke remote cluster token", async ({ page }) => {
+  const clusterName = randomClusterName();
+  await createRemoteClusterToken(page, clusterName);
+  await revokeRemoteClusterToken(page, clusterName);
+});

--- a/ui/tests/remote-clusters.spec.ts
+++ b/ui/tests/remote-clusters.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+import {
+  approvePendingCluster,
+  checkClusterExistInTable,
+  deletePendingCluster,
+} from "./helpers/remote-clusters";
+
+test("approve a pending cluster", async ({ page }) => {
+  const clusterName = await approvePendingCluster(page);
+  const clusterIsActive = await checkClusterExistInTable(
+    page,
+    clusterName,
+    "Active",
+  );
+  expect(clusterIsActive).toBe(true);
+});
+
+test("delete pending cluster", async ({ page }) => {
+  const clusterName = await deletePendingCluster(page);
+  const clusterExists = await checkClusterExistInTable(
+    page,
+    clusterName,
+    "Pending",
+  );
+  expect(clusterExists).toBe(false);
+});

--- a/ui/tests/settings.spec.ts
+++ b/ui/tests/settings.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "@playwright/test";
+import {
+  goToSettingsPage,
+  updateManagerSetting,
+  updateMemberSetting,
+  validateSettingValue,
+} from "./helpers/settings";
+
+const MANAGER_SETTINGS = [
+  "oidc.issuer",
+  "oidc.client.id",
+  "oidc.audience",
+  "global.address",
+];
+
+const MEMBER_SETTINGS = ["https_address", "external_address"];
+
+// NOTE: this is an assumption that the manager system in the testing environment has a member with the name "member1"
+const MEMBER_NAME = "member1";
+
+test("all manager settings exists", async ({ page }) => {
+  await goToSettingsPage(page);
+  for (const setting of MANAGER_SETTINGS) {
+    const settingRow = page.getByText(setting);
+    await expect(settingRow).toBeVisible();
+  }
+});
+
+test("all member settings exists", async ({ page }) => {
+  await goToSettingsPage(page);
+  const memberConfigRows = page
+    .getByRole("row")
+    .filter({ hasText: MEMBER_NAME });
+  await expect(memberConfigRows).toHaveCount(2);
+  await expect(memberConfigRows.nth(0)).toContainText(
+    `${MEMBER_NAME}.${MEMBER_SETTINGS[0]}`,
+  );
+  await expect(memberConfigRows.nth(1)).toContainText(
+    `${MEMBER_NAME}.${MEMBER_SETTINGS[1]}`,
+  );
+});
+
+// NOTE: we DO NOT want to edit the oidc settings since it will break the login flow
+test("edit manager setting global.address", async ({ page }) => {
+  await goToSettingsPage(page);
+  const settingValue = "http://localhost:8080";
+  const settingRow = await updateManagerSetting(
+    page,
+    "global.address",
+    settingValue,
+  );
+  await validateSettingValue(settingRow, settingValue);
+});
+
+test("edit member settings", async ({ page }) => {
+  await goToSettingsPage(page);
+  let settingValue = "0.0.0.0:9801";
+  let settingRow = await updateMemberSetting(
+    page,
+    MEMBER_NAME,
+    "https_address",
+    settingValue,
+  );
+  await validateSettingValue(settingRow, settingValue);
+
+  settingValue = "0.0.0.0:9810";
+  settingRow = await updateMemberSetting(
+    page,
+    MEMBER_NAME,
+    "external_address",
+    settingValue,
+  );
+  await validateSettingValue(settingRow, settingValue);
+});


### PR DESCRIPTION
## Done
Added tests for:
 - create join token
 - revoke join token
 - approve pending cluster (assert cluster exist in active clusters list)
 - delete pending cluster
 - edit manager configs (global.address)
 - edit member configs