### PR TITLE
feat: add confirmation modal for delete actions [WD-13690]

### DIFF
--- a/ui/src/pages/clusters/DeleteClusterButton.tsx
+++ b/ui/src/pages/clusters/DeleteClusterButton.tsx
@@ -1,4 +1,4 @@
-import { ActionButton, useNotify } from "@canonical/react-components";
+import { ConfirmationButton, useNotify } from "@canonical/react-components";
 import { useQueryClient } from "@tanstack/react-query";
 import { deleteCluster } from "api/clusters";
 import { FC, useState } from "react";
@@ -15,29 +15,40 @@ const DeleteClusterButton: FC<Props> = ({ clusterName }) => {
 
   const handleDeleteCluster = async () => {
     setLoading(true);
-
     try {
       await deleteCluster(clusterName);
       await queryClient.invalidateQueries({
         queryKey: [queryKeys.clusters],
       });
-      setLoading(false);
       notify.success(`Successfully deleted cluster ${clusterName}.`);
     } catch (error) {
-      setLoading(false);
       notify.failure(`Unable to delete cluster ${clusterName}.`, error);
     }
+    setLoading(false);
   };
 
   return (
-    <ActionButton
-      className="u-no-margin--bottom"
-      onClick={() => void handleDeleteCluster()}
+    <ConfirmationButton
       appearance="negative"
       loading={isLoading}
+      className="u-no-margin--bottom"
+      confirmationModalProps={{
+        title: "Confirm delete",
+        children: (
+          <p>
+            This will permanently delete the cluster{" "}
+            <strong>{clusterName}</strong>. This action cannot be undone, and
+            can result in data loss.
+          </p>
+        ),
+        confirmButtonLabel: "Delete",
+        onConfirm: () => void handleDeleteCluster(),
+      }}
+      shiftClickEnabled
+      showShiftClickHint
     >
       Delete
-    </ActionButton>
+    </ConfirmationButton>
   );
 };
 

--- a/ui/src/pages/clusters/RevokeTokenButton.tsx
+++ b/ui/src/pages/clusters/RevokeTokenButton.tsx
@@ -1,6 +1,6 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { ActionButton, useNotify } from "@canonical/react-components";
+import { ConfirmationButton, useNotify } from "@canonical/react-components";
 import { deleteToken } from "api/tokens";
 import { Token } from "types/token";
 import { queryKeys } from "util/queryKeys";
@@ -12,30 +12,49 @@ interface Props {
 const RevokeTokenButton: FC<Props> = ({ token }) => {
   const queryClient = useQueryClient();
   const notify = useNotify();
+  const [loading, setLoading] = useState(false);
 
   const handleDeleteToken = async () => {
+    setLoading(true);
     await deleteToken(token.cluster_name)
       .then(() => {
         void queryClient.invalidateQueries({
           queryKey: [queryKeys.tokens],
         });
         notify.success(
-          `Successfully deleted token for cluster ${token.cluster_name}.`,
+          `Successfully revoked token for cluster ${token.cluster_name}.`,
         );
       })
       .catch((e: Error) => {
-        notify.failure(`Unable to delete token ${token.cluster_name}.`, e);
+        notify.failure(`Unable to revoke token ${token.cluster_name}.`, e);
+      })
+      .finally(() => {
+        setLoading(false);
       });
   };
 
   return (
-    <ActionButton
-      className="u-no-margin"
+    <ConfirmationButton
       appearance="negative"
-      onClick={() => void handleDeleteToken()}
+      loading={loading}
+      className="u-no-margin--bottom"
+      confirmationModalProps={{
+        title: "Confirm revoke",
+        children: (
+          <p>
+            This will permanently revoke the token for cluster{" "}
+            <strong>{token.cluster_name}</strong>. This action cannot be undone,
+            and can result in data loss.
+          </p>
+        ),
+        confirmButtonLabel: "Revoke",
+        onConfirm: () => void handleDeleteToken(),
+      }}
+      shiftClickEnabled
+      showShiftClickHint
     >
       Revoke
-    </ActionButton>
+    </ConfirmationButton>
   );
 };
 


### PR DESCRIPTION
## Done
 - introduced confirmation modal for revoke cluster token and delete pending cluster actions.

## QA
 - revoke a token. Make sure the confirmation modal displays and has reasonable wording.
 - delete a pending cluster. Make sure the confirmation modal displays and has reasonable wording.

## Screenshots
![Screenshot from 2024-08-01 13-09-36](https://github.com/user-attachments/assets/d1ad75c4-0be2-476d-86a2-2f3191651026)
![Screenshot from 2024-08-01 13-10-14](https://github.com/user-attachments/assets/7f07c708-2d9e-4f85-8f90-1c6f9c65352b)
