### PR TITLE
fix: remove microcluster.Microcluster from cluster manager state

### DIFF
--- a/internal/api/member_configs.go
+++ b/internal/api/member_configs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	microClient "github.com/canonical/microcluster/client"
+	"github.com/canonical/microcluster/microcluster"
 	"github.com/canonical/microcluster/rest"
 	microTypes "github.com/canonical/microcluster/rest/types"
 	microState "github.com/canonical/microcluster/state"
@@ -27,7 +28,7 @@ func memberConfigCmd(s *state.ClusterManagerState) rest.Endpoint {
 	return rest.Endpoint{
 		Path: "member/{name}/config",
 		Patch: rest.EndpointAction{
-			Handler:        memberConfigPatch(s),
+			Handler:        memberConfigPatch,
 			AllowUntrusted: true,
 			AccessHandler:  authHandler(s),
 		},
@@ -51,140 +52,143 @@ func memberConfigsCmd(s *state.ClusterManagerState) rest.Endpoint {
 }
 
 // update existing member configs.
-func memberConfigPatch(clusterManagerState *state.ClusterManagerState) types.EndpointHandler {
-	return func(microState microState.State, r *http.Request) response.Response {
-		memberName, err := url.PathUnescape(mux.Vars(r)["name"])
-		if err != nil {
-			return response.BadRequest(err)
-		}
-
-		var payload types.MemberConfigPatch
-		err = json.NewDecoder(r.Body).Decode(&payload)
-		if err != nil {
-			return response.BadRequest(err)
-		}
-
-		HTTPSAddress, hasHTTPSAddress := payload.Config[types.HTTPSAddress]
-		externalAddress, hasExternalAddress := payload.Config[types.ExternalAddress]
-
-		if !hasHTTPSAddress && !hasExternalAddress {
-			return response.BadRequest(fmt.Errorf("no fields provided to update"))
-		}
-
-		if hasExternalAddress && externalAddress != "" {
-			_, err = microTypes.ParseAddrPort(externalAddress)
-			if err != nil {
-				return response.BadRequest(fmt.Errorf("invalid external_address for member %q: %w", memberName, err))
-			}
-		}
-
-		reverter := revert.New()
-		defer reverter.Fail()
-
-		queryClient, err := getClientByName(microState, clusterManagerState, memberName)
-		if err != nil {
-			return response.InternalError(fmt.Errorf("failed to get client for member %q: %w", memberName, err))
-		}
-
-		if hasHTTPSAddress {
-			newAddress, err := microTypes.ParseAddrPort(HTTPSAddress)
-			if err != nil {
-				return response.BadRequest(fmt.Errorf("invalid https_address for member %q: %w", memberName, err))
-			}
-
-			// the control listener address is stored in a member's local state directory
-			// we need to update the control listener address, we need to forward the request to the relevant member and let the update happen there
-			if memberName != microState.Name() {
-				queryClient.SetClusterNotification()
-				err = client.MemberConfigPatchCmd(r.Context(), queryClient, memberName, &payload)
-				if err != nil {
-					return response.InternalError(fmt.Errorf("failed to update member %q config: %w", memberName, err))
-				}
-
-				return response.EmptySyncResponse
-			}
-
-			// update the control listener address for local member configs
-			newServerConfig := make(map[string]microTypes.ServerConfig)
-			existingServerConfig, err := client.GetDaemonServerConfigs(r.Context(), queryClient)
-			if err != nil {
-				return response.InternalError(fmt.Errorf("failed to get local member %q config: %w", memberName, err))
-			}
-
-			for name, config := range existingServerConfig {
-				if name == string(ControlListener) {
-					config.Address = newAddress
-				}
-
-				newServerConfig[name] = config
-			}
-
-			localClient, err := clusterManagerState.MicroCluster.LocalClient()
-			if err != nil {
-				return response.InternalError(fmt.Errorf("failed to get local client: %w", err))
-			}
-
-			err = localClient.UpdateServers(r.Context(), newServerConfig)
-			if err != nil {
-				return response.InternalError(fmt.Errorf("failed to update local member %q config: %w", memberName, err))
-			}
-
-			// in case if the dqlite transaction fails to update the member config, we need to revert the control listener address update
-			// this will keep daemon local configs in sync with what's stored in dqlite
-			reverter.Add(func() {
-				err := localClient.UpdateServers(r.Context(), existingServerConfig)
-				if err != nil {
-					logger.Warn("Failed to revert control listener address update, data may be inconsistent")
-				}
-
-				logger.Warn("Reverted control listener address update")
-			})
-		}
-
-		err = microState.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
-			// get existing member config entry and use it as a base
-			filter := database.ManagerMemberConfigFilter{
-				Target: &memberName,
-			}
-
-			dbConfigs, err := database.GetManagerMemberConfig(ctx, tx, filter)
-			if err != nil {
-				return err
-			}
-
-			// if no external address is provided, keep the existing one
-			if !hasExternalAddress {
-				externalAddress = dbConfigs[0].ExternalAddress
-			}
-
-			serverConfigs, err := client.GetDaemonServerConfigs(r.Context(), queryClient)
-			if err != nil {
-				return fmt.Errorf("failed to get local member %q config: %w", memberName, err)
-			}
-
-			controlListenerConfig, ok := serverConfigs[string(ControlListener)]
-			if !ok {
-				return fmt.Errorf("control listener config not found")
-			}
-
-			httpsAddress := controlListenerConfig.Address.String()
-
-			// It is expected a member config entry was created for every member during initialisation
-			return database.UpdateManagerMemberConfig(ctx, tx, memberName, database.ManagerMemberConfig{
-				Target:          memberName,
-				HTTPSAddress:    httpsAddress,
-				ExternalAddress: externalAddress,
-			})
-		})
-
-		if err != nil {
-			return response.SmartError(err)
-		}
-
-		reverter.Success()
-
-		return response.EmptySyncResponse
+func memberConfigPatch(microState microState.State, r *http.Request) response.Response {
+	memberName, err := url.PathUnescape(mux.Vars(r)["name"])
+	if err != nil {
+		return response.BadRequest(err)
 	}
+
+	var payload types.MemberConfigPatch
+	err = json.NewDecoder(r.Body).Decode(&payload)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	HTTPSAddress, hasHTTPSAddress := payload.Config[types.HTTPSAddress]
+	externalAddress, hasExternalAddress := payload.Config[types.ExternalAddress]
+
+	if !hasHTTPSAddress && !hasExternalAddress {
+		return response.BadRequest(fmt.Errorf("no fields provided to update"))
+	}
+
+	if hasExternalAddress && externalAddress != "" {
+		_, err = microTypes.ParseAddrPort(externalAddress)
+		if err != nil {
+			return response.BadRequest(fmt.Errorf("invalid external_address for member %q: %w", memberName, err))
+		}
+	}
+
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	queryClient, err := getClientByName(microState, memberName)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to get client for member %q: %w", memberName, err))
+	}
+
+	if hasHTTPSAddress {
+		newAddress, err := microTypes.ParseAddrPort(HTTPSAddress)
+		if err != nil {
+			return response.BadRequest(fmt.Errorf("invalid https_address for member %q: %w", memberName, err))
+		}
+
+		// the control listener address is stored in a member's local state directory
+		// we need to update the control listener address, we need to forward the request to the relevant member and let the update happen there
+		if memberName != microState.Name() {
+			queryClient.SetClusterNotification()
+			err = client.MemberConfigPatchCmd(r.Context(), queryClient, memberName, &payload)
+			if err != nil {
+				return response.InternalError(fmt.Errorf("failed to update member %q config: %w", memberName, err))
+			}
+
+			return response.EmptySyncResponse
+		}
+
+		// update the control listener address for local member configs
+		newServerConfig := make(map[string]microTypes.ServerConfig)
+		existingServerConfig, err := client.GetDaemonServerConfigs(r.Context(), queryClient)
+		if err != nil {
+			return response.InternalError(fmt.Errorf("failed to get local member %q config: %w", memberName, err))
+		}
+
+		for name, config := range existingServerConfig {
+			if name == string(ControlListener) {
+				config.Address = newAddress
+			}
+
+			newServerConfig[name] = config
+		}
+
+		m, err := microcluster.App(microcluster.Args{StateDir: microState.FileSystem().StateDir})
+		if err != nil {
+			return response.InternalError(fmt.Errorf("failed to get microcluster app: %w", err))
+		}
+
+		localClient, err := m.LocalClient()
+		if err != nil {
+			return response.InternalError(fmt.Errorf("failed to get local client: %w", err))
+		}
+
+		err = localClient.UpdateServers(r.Context(), newServerConfig)
+		if err != nil {
+			return response.InternalError(fmt.Errorf("failed to update local member %q config: %w", memberName, err))
+		}
+
+		// in case if the dqlite transaction fails to update the member config, we need to revert the control listener address update
+		// this will keep daemon local configs in sync with what's stored in dqlite
+		reverter.Add(func() {
+			err := localClient.UpdateServers(r.Context(), existingServerConfig)
+			if err != nil {
+				logger.Warn("Failed to revert control listener address update, data may be inconsistent")
+			}
+
+			logger.Warn("Reverted control listener address update")
+		})
+	}
+
+	err = microState.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		// get existing member config entry and use it as a base
+		filter := database.ManagerMemberConfigFilter{
+			Target: &memberName,
+		}
+
+		dbConfigs, err := database.GetManagerMemberConfig(ctx, tx, filter)
+		if err != nil {
+			return err
+		}
+
+		// if no external address is provided, keep the existing one
+		if !hasExternalAddress {
+			externalAddress = dbConfigs[0].ExternalAddress
+		}
+
+		serverConfigs, err := client.GetDaemonServerConfigs(r.Context(), queryClient)
+		if err != nil {
+			return fmt.Errorf("failed to get local member %q config: %w", memberName, err)
+		}
+
+		controlListenerConfig, ok := serverConfigs[string(ControlListener)]
+		if !ok {
+			return fmt.Errorf("control listener config not found")
+		}
+
+		httpsAddress := controlListenerConfig.Address.String()
+
+		// It is expected a member config entry was created for every member during initialisation
+		return database.UpdateManagerMemberConfig(ctx, tx, memberName, database.ManagerMemberConfig{
+			Target:          memberName,
+			HTTPSAddress:    httpsAddress,
+			ExternalAddress: externalAddress,
+		})
+	})
+
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	reverter.Success()
+
+	return response.EmptySyncResponse
 }
 
 func memberConfigGet(s microState.State, r *http.Request) response.Response {
@@ -247,9 +251,14 @@ func toMemberConfigsAPI(dbConfigs []database.ManagerMemberConfig) []types.Member
 	return memberConfigs
 }
 
-func getClientByName(microState microState.State, clusterManagerState *state.ClusterManagerState, name string) (*microClient.Client, error) {
+func getClientByName(microState microState.State, name string) (*microClient.Client, error) {
+	m, err := microcluster.App(microcluster.Args{StateDir: microState.FileSystem().StateDir})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get microcluster app: %w", err)
+	}
+
 	if microState.Name() == name {
-		localClient, err := clusterManagerState.MicroCluster.LocalClient()
+		localClient, err := m.LocalClient()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get local client: %w", err)
 		}
@@ -263,7 +272,7 @@ func getClientByName(microState microState.State, clusterManagerState *state.Clu
 		return nil, fmt.Errorf("member %q not found", name)
 	}
 
-	client, err := clusterManagerState.MicroCluster.RemoteClient(targetRemote.Address.String())
+	client, err := m.RemoteClient(targetRemote.Address.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get remote client for member: %s", name)
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -12,16 +12,12 @@ import (
 type ClusterManagerState struct {
 	// OIDCVerifier is the OpenID Connect verifier used for user authentication and validate authentication for protected API endpoints.
 	OIDCVerifier *oidc.Verifier
-	// MicroCluster is the MicroCluster instance.
-	MicroCluster *microcluster.MicroCluster
 	mu           sync.RWMutex
 }
 
 // New creates a new ClusterManagerState.
 func New(m *microcluster.MicroCluster) *ClusterManagerState {
-	return &ClusterManagerState{
-		MicroCluster: m,
-	}
+	return &ClusterManagerState{}
 }
 
 // SetOIDCVerifier sets the OIDCVerifier.


### PR DESCRIPTION
## Done
- previously we had `microcluster.Microcluster` inside cluster manager state in order to access it from within endpoints. This is not needed since we can simply create it with `microcluster.App`. This PR removes `microcluster.Microcluster` from the cluster manager state.