### PR TITLE
feat: Add help texts for configuration fields [WD-13689]

### DIFF
--- a/internal/api/configuration.go
+++ b/internal/api/configuration.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"embed"
+	"encoding/json"
+	"net/http"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/rest"
+	microState "github.com/canonical/microcluster/state"
+
+	"github.com/canonical/lxd-cluster-manager/internal/state"
+)
+
+//go:embed metadata/configuration.json
+var configJSON embed.FS
+
+func metadataConfigurationCmd(s *state.ClusterManagerState) rest.Endpoint {
+	return rest.Endpoint{
+		Path: "metadata/configuration",
+		Get: rest.EndpointAction{
+			Handler:        metadataConfigurationGet,
+			AllowUntrusted: true,
+			AccessHandler:  authHandler(s),
+		},
+	}
+}
+
+func metadataConfigurationGet(_ microState.State, r *http.Request) response.Response {
+	file, err := configJSON.ReadFile("metadata/configuration.json")
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	var data map[string]any
+	err = json.Unmarshal(file, &data)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.SyncResponse(true, data)
+}

--- a/internal/api/metadata/configuration.json
+++ b/internal/api/metadata/configuration.json
@@ -1,0 +1,68 @@
+{
+	"configs": {
+		"cluster": {
+            "oidc": {
+                "keys": [
+                    {
+						"oidc.audience": {
+							"longdesc": "This value is required by some providers.",
+							"shortdesc": "Expected audience value for the application",
+							"scope": "global",
+							"type": "string"
+						}
+					},
+					{
+						"oidc.client.id": {
+							"longdesc": "",
+							"shortdesc": "OpenID Connect client ID",
+							"scope": "global",
+							"type": "string"
+						}
+					},
+					{
+						"oidc.issuer": {
+							"longdesc": "",
+							"shortdesc": "OpenID Connect Discovery URL for the provider",
+							"scope": "global",
+							"type": "string"
+						}
+					}
+                ]
+            },
+            "global": {
+                "keys": [
+                    {
+                        "global.address": {
+                            "longdesc": "This value is optional. If set, it will be used as the address for the control network listener and will override member level addresses.",
+                            "shortdesc": "Address to bind a load balancer or authoritative DNS server to",
+							"scope": "global",
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+		},
+		"member": {
+            "member": {
+                "keys": [
+                    {
+						"https_address": {
+							"longdesc": "This value is required and is set during the manager installation process. Updating this setting may result in the member becoming unreachable.",
+							"shortdesc": "Internal member address for the member control network listener",
+							"scope": "local",
+							"type": "string"
+						}
+					},
+					{
+						"external_address": {
+							"longdesc": "This value is optional. If set, its value will be used as the reachable address for the member control network listener.",
+							"shortdesc": "External address mapping to the internal address of the member control network listener",
+							"scope": "local",
+							"type": "string"
+						}
+					}
+                ]
+            }
+		}
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -38,6 +38,7 @@ func remoteClusterManagementListener(s *state.ClusterManagerState) rest.Server {
 				PathPrefix: types.APIVersionPrefix,
 				Endpoints: []rest.Endpoint{
 					apiRootCmd(s),
+					metadataConfigurationCmd(s),
 					remoteClusterCmd(s),
 					remoteClustersCmd(s),
 					managerConfigsCmd(s),

--- a/ui/src/api/server.ts
+++ b/ui/src/api/server.ts
@@ -1,4 +1,5 @@
 import { LxdApiResponse } from "types/apiResponse";
+import { ConfigOptions } from "types/config";
 import { Server } from "types/server";
 import { handleResponse } from "util/helpers";
 
@@ -7,6 +8,15 @@ export const fetchServer = (): Promise<Server> => {
     fetch("/1.0")
       .then(handleResponse)
       .then((data: LxdApiResponse<Server>) => resolve(data.metadata))
+      .catch(reject);
+  });
+};
+
+export const fetchConfigOptions = (): Promise<ConfigOptions | null> => {
+  return new Promise((resolve, reject) => {
+    fetch("/1.0/metadata/configuration")
+      .then(handleResponse)
+      .then((data: LxdApiResponse<ConfigOptions>) => resolve(data.metadata))
       .catch(reject);
   });
 };

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -11,16 +11,31 @@ import SettingForm from "./settings/SettingForm";
 import { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
 import { ManagerOptions, MemberOptions } from "types/config";
 import NotificationRow from "components/NotificationRow";
+import ConfigFieldDescription from "./settings/ConfigFieldDescription";
+import { fetchConfigOptions } from "api/server";
+import Loader from "components/Loader";
+import { getConfigMetadata } from "util/config";
 
 const Settings: FC = () => {
-  const { data: managerConfigOptions } = useQuery({
+  const {
+    data: managerConfigOptions,
+    isLoading: isManagerConfigOptionsLoading,
+  } = useQuery({
     queryKey: [queryKeys.managerConfigOptions],
     queryFn: fetchManagerConfigOptions,
   });
 
-  const { data: memberConfigOptions = [] } = useQuery({
+  const {
+    data: memberConfigOptions = [],
+    isLoading: isMemberConfigOptionsLoading,
+  } = useQuery({
     queryKey: [queryKeys.memberConfigOptions],
     queryFn: fetchMemberConfigOptions,
+  });
+
+  const { data: configOptions, isLoading: isConfigOptionsLoading } = useQuery({
+    queryKey: [queryKeys.configOptions],
+    queryFn: () => fetchConfigOptions(),
   });
 
   const defaultManagerConfigs: ManagerOptions["config"] = {
@@ -41,6 +56,8 @@ const Settings: FC = () => {
     { content: "Value" },
   ];
 
+  const configMetadata = getConfigMetadata(configOptions || undefined);
+
   const generateManagerConfigRows = () => {
     const configKeys = Object.keys(defaultManagerConfigs);
 
@@ -56,7 +73,15 @@ const Settings: FC = () => {
             "aria-label": "Scope",
           },
           {
-            content: <div className="key-cell">{key}</div>,
+            content: (
+              <div className="key-cell">
+                {key}
+                <ConfigFieldDescription
+                  description={configMetadata[key]?.shortdesc}
+                  className="p-text--small u-text--muted u-no-margin--bottom"
+                />
+              </div>
+            ),
             role: "cell",
             className: "key",
             "aria-label": "Key",
@@ -64,7 +89,7 @@ const Settings: FC = () => {
           {
             content: (
               <SettingForm
-                configField={key}
+                configField={configMetadata[key]}
                 value={
                   managerConfigOptions?.config[key] ||
                   defaultManagerConfigs[key]
@@ -113,8 +138,12 @@ const Settings: FC = () => {
             },
             {
               content: (
-                <div className="key-cell u-truncate" title={memberConfigKey}>
-                  {memberConfigKey}
+                <div className="key-cell" title={memberConfigKey}>
+                  <span className="u-truncate">{memberConfigKey}</span>
+                  <ConfigFieldDescription
+                    description={configMetadata[key]?.shortdesc}
+                    className="p-text--small u-text--muted u-no-margin--bottom"
+                  />
                 </div>
               ),
               role: "cell",
@@ -124,7 +153,7 @@ const Settings: FC = () => {
             {
               content: (
                 <SettingForm
-                  configField={key}
+                  configField={configMetadata[key]}
                   value={memberConfig.config[key] || defaultMemberConfigs[key]}
                   isLast={index === length - 1}
                   member={memberConfig.target}
@@ -145,6 +174,14 @@ const Settings: FC = () => {
   };
 
   const rows = [...generateManagerConfigRows(), ...generateMemberConfigRows()];
+
+  if (
+    isConfigOptionsLoading ||
+    isManagerConfigOptionsLoading ||
+    isMemberConfigOptionsLoading
+  ) {
+    return <Loader />;
+  }
 
   return (
     <BaseLayout title="Settings">

--- a/ui/src/pages/settings/ConfigFieldDescription.tsx
+++ b/ui/src/pages/settings/ConfigFieldDescription.tsx
@@ -1,0 +1,20 @@
+import { FC } from "react";
+import { configDescriptionToHtml } from "util/config";
+
+interface Props {
+  description?: string;
+  className?: string;
+}
+
+const ConfigFieldDescription: FC<Props> = ({ description, className }) => {
+  return description ? (
+    <p
+      className={className}
+      dangerouslySetInnerHTML={{
+        __html: configDescriptionToHtml(description),
+      }}
+    ></p>
+  ) : null;
+};
+
+export default ConfigFieldDescription;

--- a/ui/src/pages/settings/SettingForm.tsx
+++ b/ui/src/pages/settings/SettingForm.tsx
@@ -4,9 +4,10 @@ import { updateManagerConfigs, updateMemberConfigs } from "api/settings";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import SettingFormInput from "./SettingFormInput";
+import { ConfigField } from "types/config";
 
 interface Props {
-  configField: string;
+  configField: ConfigField;
   value?: string;
   isLast?: boolean;
   member?: string;
@@ -21,7 +22,7 @@ const SettingForm: FC<Props> = ({ configField, value, isLast, member }) => {
 
   const onSubmit = (newValue: string | boolean) => {
     const config = {
-      [configField]: String(newValue),
+      [configField.key]: String(newValue),
     };
 
     (member
@@ -30,7 +31,7 @@ const SettingForm: FC<Props> = ({ configField, value, isLast, member }) => {
     )
       .then(() => {
         setEditMode(false);
-        notify.success(`Setting ${configField} updated.`);
+        notify.success(`Setting ${configField.key} updated.`);
       })
       .catch((e) => {
         notify.failure("Setting update failed", e);

--- a/ui/src/pages/settings/SettingFormInput.tsx
+++ b/ui/src/pages/settings/SettingFormInput.tsx
@@ -1,9 +1,11 @@
 import { FC, useState } from "react";
 import { Button, Form, Input } from "@canonical/react-components";
+import { ConfigField } from "types/config";
+import ConfigFieldDescription from "./ConfigFieldDescription";
 
 interface Props {
   initialValue: string;
-  configField: string;
+  configField: ConfigField;
   onSubmit: (newValue: string | boolean) => void;
   onCancel: () => void;
 }
@@ -34,12 +36,18 @@ const SettingFormInput: FC<Props> = ({
       {/* hidden submit to enable enter key in inputs */}
       <Input type="submit" hidden value="Hidden input" />
       <Input
-        aria-label={configField}
-        id={getConfigId(configField)}
+        aria-label={configField.key}
+        id={getConfigId(configField.key)}
         wrapperClassName="input-wrapper"
         type={getInputType()}
         value={String(value)}
         onChange={(e) => setValue(e.target.value)}
+        help={
+          <ConfigFieldDescription
+            description={configField.longdesc}
+            className="p-form-help-text"
+          />
+        }
       />
       <Button appearance="base" onClick={onCancel}>
         Cancel

--- a/ui/src/types/config.d.ts
+++ b/ui/src/types/config.d.ts
@@ -13,3 +13,32 @@ interface MemberOptions {
     external_address?: string;
   };
 }
+
+export type ConfigField = ConfigOption & {
+  category: string;
+  key: string;
+};
+
+export interface ConfigOption {
+  longdesc?: string;
+  scope?: "global" | "local";
+  shortdesc?: string;
+  type: "bool" | "string" | "integer";
+}
+
+export interface ConfigOptionCategories {
+  [category: string]: {
+    keys: {
+      [key: string]: ConfigOption;
+    }[];
+  };
+}
+
+export interface ConfigOptions {
+  configs: {
+    cluster: ConfigOptionCategories;
+    member: ConfigOptionCategories;
+  };
+}
+
+export type ConfigOptionsKeys = keyof ConfigOptions["configs"];

--- a/ui/src/util/config.tsx
+++ b/ui/src/util/config.tsx
@@ -1,0 +1,53 @@
+import { ConfigField, ConfigOptions, ConfigOptionsKeys } from "types/config";
+
+export const configDescriptionToHtml = (input: string): string => {
+  // special characters
+  let result = input
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\n", "<br>");
+
+  // replace admonition markup
+  result = result
+    .replaceAll("```", "")
+    .replaceAll("{important}", "<b>Important</b>");
+
+  // code blocks
+  let count = 0;
+  const maxCodeblockReplacementCount = 100; // avoid infinite loop
+  while (result.includes("`") && count++ < maxCodeblockReplacementCount) {
+    result = result.replace("`", "<code>").replace("`", "</code>");
+  }
+
+  return result;
+};
+
+export const getConfigMetadata = (
+  configOptions?: ConfigOptions,
+): Record<string, ConfigField> => {
+  if (!configOptions) {
+    return {};
+  }
+
+  const configMetadata: Record<string, ConfigField> = {};
+
+  for (const entity in configOptions.configs) {
+    const configEntityCategories =
+      configOptions.configs[entity as ConfigOptionsKeys];
+
+    for (const category in configEntityCategories) {
+      const categoryKeys = configEntityCategories[category].keys;
+
+      for (const config of categoryKeys) {
+        const [key, value] = Object.entries(config)[0];
+        configMetadata[key] = {
+          ...value,
+          category: category,
+          key,
+        };
+      }
+    }
+  }
+
+  return configMetadata;
+};

--- a/ui/src/util/queryKeys.tsx
+++ b/ui/src/util/queryKeys.tsx
@@ -4,4 +4,5 @@ export const queryKeys = {
   memberConfigOptions: "memberConfigOptions",
   tokens: "tokens",
   server: "server",
+  configOptions: "configOptions",
 };


### PR DESCRIPTION
## Done
 - Added `1.0/metadata/configuration` endpoint for returning helpful config info
 - Adjusted settings page to display help text for various settings

## QA
 - Go to the settings page and check that help text is displayed.

## Screenshot
![Screenshot from 2024-08-06 11-29-16](https://github.com/user-attachments/assets/45d2ac4c-3586-4756-8454-0528dd020550)
