### PR TITLE
feat: [WD-13078] Added search and filter for cluster list

### DIFF
--- a/scripts/generate_clusters.sh
+++ b/scripts/generate_clusters.sh
@@ -43,8 +43,8 @@ for i in $(seq 1 $ENTRIES); do
     DISK_USAGE=$(( (SEED * 12345678) % (DISK_TOTAL_SIZE + 1) ))  # 0 to DISK_TOTAL_SIZE
     # Generates a random date and time between date.now and 30 minutes ago.
     LAST_UPDATED_AT=$(date -u -d "@$(( $(date -u -d '30 minutes ago' +%s) + SEED % ($(date -u +%s) - $(date -u -d '30 minutes ago' +%s)) ))" +'%Y-%m-%d %H:%M:%S')
-    INSTANCE_STATUSES=$(printf "$INSTANCE_STATUSES_TEMPLATE" $((SEED % 200 + 1)) $((SEED % 150 + 1)) $((SEED % 100 + 1)) $((SEED % 50 + 1)))
-    MEMBER_STATUSES=$(printf "$MEMBER_STATUSES_TEMPLATE" $((SEED % 4 + 1)) $((SEED % 3 + 1)) $((SEED % 2 + 1)) $((SEED % 1 + 1)))
+    INSTANCE_STATUSES=$(printf "$INSTANCE_STATUSES_TEMPLATE" $((SEED % 200)) $((SEED % 150 + 1)) $((SEED % 100 + 1)) $((SEED % 35 + 1)))
+    MEMBER_STATUSES=$(printf "$MEMBER_STATUSES_TEMPLATE" $((SEED % 4)) $((SEED % 3 + 1)) $((SEED % 2 + 1)) $((SEED % 1 + 1)))
     REMOTE_CLUSTER_DETAILS_VALUES+=("($CORE_REMOTE_CLUSTER_ID, '$STATUS', '$CPU_TOTAL_COUNT', '$CPU_LOAD_1', '$CPU_LOAD_5', '$CPU_LOAD_15', '$MEMORY_TOTAL_AMOUNT', '$MEMORY_USAGE', '$DISK_TOTAL_SIZE', '$DISK_USAGE', '$INSTANCE_COUNT', '$INSTANCE_STATUSES', '$MEMBER_COUNT', '$MEMBER_STATUSES', '$LAST_UPDATED_AT')")
 done
 

--- a/ui/src/components/CustomLayout.tsx
+++ b/ui/src/components/CustomLayout.tsx
@@ -1,0 +1,30 @@
+import { FC, ReactNode } from "react";
+import classnames from "classnames";
+import { AppMain } from "@canonical/react-components";
+
+interface Props {
+  header?: ReactNode;
+  children: ReactNode;
+  mainClassName?: string;
+  contentClassName?: string;
+}
+
+const CustomLayout: FC<Props> = ({
+  header,
+  children,
+  contentClassName,
+  mainClassName,
+}: Props) => {
+  return (
+    <AppMain className={mainClassName}>
+      <div className="p-panel">
+        {header}
+        <div className={classnames("p-panel__content", contentClassName)}>
+          {children}
+        </div>
+      </div>
+    </AppMain>
+  );
+};
+
+export default CustomLayout;

--- a/ui/src/components/PageHeader.tsx
+++ b/ui/src/components/PageHeader.tsx
@@ -1,0 +1,40 @@
+import { FC, PropsWithChildren } from "react";
+
+const Left: FC<PropsWithChildren> = ({ children }) => {
+  return <div className="page-header__left">{children}</div>;
+};
+
+const Title: FC<PropsWithChildren> = ({ children }) => {
+  return <h1 className="p-heading--4 u-no-margin--bottom">{children}</h1>;
+};
+
+const Search: FC<PropsWithChildren> = ({ children }) => {
+  return (
+    <div className="page-header__search margin-right u-no-margin--bottom">
+      {children}
+    </div>
+  );
+};
+
+const BaseActions: FC<PropsWithChildren> = ({ children }) => {
+  return <div className="page-header__base-actions">{children}</div>;
+};
+
+const Header: FC<PropsWithChildren> = ({ children }) => {
+  return <div className="p-panel__header page-header">{children}</div>;
+};
+
+type PageHeaderComponents = FC<PropsWithChildren> & {
+  Left: FC<PropsWithChildren>;
+  Title: FC<PropsWithChildren>;
+  Search: FC<PropsWithChildren>;
+  BaseActions: FC<PropsWithChildren>;
+};
+
+const PageHeader = Header as PageHeaderComponents;
+PageHeader.Left = Left;
+PageHeader.Title = Title;
+PageHeader.Search = Search;
+PageHeader.BaseActions = BaseActions;
+
+export default PageHeader;

--- a/ui/src/pages/clusters/AddClusterButton.tsx
+++ b/ui/src/pages/clusters/AddClusterButton.tsx
@@ -11,7 +11,7 @@ const AddClusterButton: FC = () => {
         navigate("/ui/clusters/create");
       }}
       appearance="positive"
-      className="u-no-margin--bottom"
+      className="u-float-right u-no-margin--bottom"
     >
       Add New Cluster
     </ActionButton>

--- a/ui/src/pages/clusters/ClusterList.tsx
+++ b/ui/src/pages/clusters/ClusterList.tsx
@@ -1,7 +1,6 @@
 import { FC } from "react";
 import { List, Row } from "@canonical/react-components";
-import BaseLayout from "components/BaseLayout";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import TabLinks from "components/TabLinks";
 import ClusterListTokens from "./ClusterListTokens";
 import ClusterListActive from "./ClusterListActive";
@@ -11,35 +10,154 @@ import ClusterStatusGraph from "./metrics/ClusterStatusGraph";
 import NotificationRow from "components/NotificationRow";
 import ClusterDiskGraph from "./metrics/ClusterDiskGraph";
 import ClusterMemoryGraph from "./metrics/ClusterMemoryGraph";
+import ClusterSearchFilter from "pages/clusters/ClusterSearchFilter";
+import CustomLayout from "components/CustomLayout";
+import PageHeader from "components/PageHeader";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { fetchClusters } from "api/clusters";
+import {
+  ClusterFilters,
+  toNumericUsagePercentiles,
+  hasAllMatchingStatuses,
+  hasAllUsagePercentileBands,
+} from "util/clusterFilter";
+import {
+  ClusterInstanceStatus,
+  ClusterNodeStatus,
+  ClusterPercentiles,
+} from "types/cluster";
 
 const ClusterList: FC = () => {
   const { activeTab } = useParams<{
     activeTab?: string;
   }>();
 
+  const [searchParams] = useSearchParams();
+
   const tabs: string[] = ["Active", "Pending", "Tokens"];
 
+  const { data: clusters = [], isLoading } = useQuery({
+    queryKey: [queryKeys.clusters],
+    queryFn: fetchClusters,
+  });
+
+  const filters: ClusterFilters = {
+    queries: searchParams.getAll("query"),
+    instanceStatuses: searchParams.getAll(
+      "instance-status",
+    ) as ClusterInstanceStatus[],
+    nodeStatuses: searchParams.getAll("node-status") as ClusterNodeStatus[],
+    memoryUsage: toNumericUsagePercentiles(
+      searchParams.getAll("memory-usage"),
+    ) as ClusterPercentiles[],
+    diskUsage: toNumericUsagePercentiles(
+      searchParams.getAll("disk-usage"),
+    ) as ClusterPercentiles[],
+  };
+
+  const filteredClusters = clusters.filter((item) => {
+    if (
+      //Query search by name
+      !filters.queries.every((q) => item.name.toLowerCase().includes(q))
+    ) {
+      return false;
+    }
+
+    if (
+      //Search by Clusters with more than one instance having a particular status
+      filters.instanceStatuses.length > 0 &&
+      !hasAllMatchingStatuses(filters.instanceStatuses, item.instance_statuses)
+    ) {
+      return false;
+    }
+
+    if (
+      //Search by Clusters with more than one node having a particular status
+      filters.nodeStatuses.length > 0 &&
+      !hasAllMatchingStatuses(filters.nodeStatuses, item.member_statuses)
+    ) {
+      return false;
+    }
+
+    if (
+      //Search by Cluster memory usage
+      filters.memoryUsage.length > 0 &&
+      !hasAllUsagePercentileBands(
+        filters.memoryUsage,
+        item.memory_usage,
+        item.memory_total_amount,
+      )
+    ) {
+      return false;
+    }
+
+    if (
+      //Search by Cluster disk usage
+      filters.diskUsage.length > 0 &&
+      !hasAllUsagePercentileBands(
+        filters.diskUsage,
+        item.disk_usage,
+        item.disk_total_size,
+      )
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+
   return (
-    <BaseLayout title="Clusters" controls={<AddClusterButton />}>
+    <CustomLayout
+      header={
+        <PageHeader>
+          <PageHeader.Left>
+            <PageHeader.Title>Clusters</PageHeader.Title>
+
+            <PageHeader.Search>
+              {!activeTab && <ClusterSearchFilter />}
+            </PageHeader.Search>
+          </PageHeader.Left>
+
+          <PageHeader.BaseActions>
+            <AddClusterButton />
+          </PageHeader.BaseActions>
+        </PageHeader>
+      }
+    >
       <Row>
         <List
           className="cluster-graphs"
           inline
           items={[
-            <ClusterStatusGraph key="cluster-status-graph" />,
-            <ClusterDiskGraph key="cluster-disk-graph" />,
-            <ClusterMemoryGraph key="cluster-memory-graph" />,
+            <ClusterStatusGraph
+              key="cluster-status-graph"
+              clusters={filteredClusters}
+            />,
+            <ClusterDiskGraph
+              key="cluster-disk-graph"
+              clusters={filteredClusters}
+            />,
+            <ClusterMemoryGraph
+              key="cluster-memory-graph"
+              clusters={filteredClusters}
+            />,
           ]}
         />
         <TabLinks tabs={tabs} activeTab={activeTab} tabUrl="/ui/clusters" />
         <NotificationRow />
         <div>
-          {!activeTab && <ClusterListActive />}
+          {!activeTab && (
+            <ClusterListActive
+              clusters={filteredClusters}
+              isLoading={isLoading}
+            />
+          )}
           {activeTab === "pending" && <ClusterListPending />}
           {activeTab === "tokens" && <ClusterListTokens />}
         </div>
       </Row>
-    </BaseLayout>
+    </CustomLayout>
   );
 };
 

--- a/ui/src/pages/clusters/ClusterListActive.tsx
+++ b/ui/src/pages/clusters/ClusterListActive.tsx
@@ -1,6 +1,4 @@
 import { FC } from "react";
-import { fetchClusters } from "api/clusters";
-import { useQuery } from "@tanstack/react-query";
 import { MainTable, TablePagination } from "@canonical/react-components";
 import Loader from "components/Loader";
 import { Link } from "react-router-dom";
@@ -10,15 +8,15 @@ import { ClusterMemory } from "./metrics/ClusterMemory";
 import { ClusterDisk } from "./metrics/ClusterDisk";
 import { ClusterNodes } from "./metrics/ClusterNodes";
 import ClusterHeartbeat from "./metrics/ClusterHeartbeat";
-import { queryKeys } from "util/queryKeys";
 import ClusterStatus from "./metrics/ClusterStatus";
+import { Cluster } from "types/cluster";
 
-const ClusterListActive: FC = () => {
-  const { data: clusters = [], isLoading } = useQuery({
-    queryKey: [queryKeys.clusters],
-    queryFn: fetchClusters,
-  });
+type Props = {
+  clusters: Cluster[];
+  isLoading: boolean;
+};
 
+const ClusterListActive: FC<Props> = ({ clusters, isLoading }) => {
   const filteredClusters = clusters.filter(
     (cluster) => cluster.status == "ACTIVE",
   );
@@ -88,7 +86,7 @@ const ClusterListActive: FC = () => {
       <TablePagination
         data={tableRows}
         id="pagination"
-        itemName="cluster"
+        itemName=" active cluster"
         className="u-no-margin--top"
         aria-label="Table pagination control"
       >

--- a/ui/src/pages/clusters/ClusterSearchFilter.tsx
+++ b/ui/src/pages/clusters/ClusterSearchFilter.tsx
@@ -1,0 +1,88 @@
+import { FC, memo } from "react";
+import { SearchAndFilter } from "@canonical/react-components";
+import {
+  SearchAndFilterChip,
+  SearchAndFilterData,
+} from "@canonical/react-components/dist/components/SearchAndFilter/types";
+import { useSearchParams } from "react-router-dom";
+import { paramsFromSearchData } from "util/searchAndFilter";
+import {
+  instanceStatuses,
+  nodeStatuses,
+  usagePercentiles,
+} from "util/clusterFilter";
+
+export const QUERY = "query";
+export const NAME = "name";
+export const INSTANCE_STATUS = "instance-status";
+export const NODE_STATUS = "node-status";
+export const MEMORY_USAGE = "memory-usage";
+export const DISK_USAGE = "disk-usage";
+
+const QUERY_PARAMS = [
+  QUERY,
+  NAME,
+  INSTANCE_STATUS,
+  NODE_STATUS,
+  MEMORY_USAGE,
+  DISK_USAGE,
+];
+
+const ClusterSearchFilter: FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const searchAndFilterData: SearchAndFilterData[] = [
+    {
+      id: 1,
+      heading: "Instance status",
+      chips: instanceStatuses.map((status) => {
+        return { lead: INSTANCE_STATUS, value: status };
+      }),
+    },
+    {
+      id: 2,
+      heading: "Node status",
+      chips: nodeStatuses.map((status) => {
+        return { lead: NODE_STATUS, value: status };
+      }),
+    },
+    {
+      id: 3,
+      heading: "Memory Usage",
+      chips: usagePercentiles.map((percentile) => {
+        return { lead: MEMORY_USAGE, value: percentile };
+      }),
+    },
+    {
+      id: 4,
+      heading: "Disk Usage",
+      chips: usagePercentiles.map((percentile) => {
+        return { lead: DISK_USAGE, value: percentile };
+      }),
+    },
+  ];
+
+  const onSearchDataChange = (searchData: SearchAndFilterChip[]) => {
+    const newParams = paramsFromSearchData(
+      searchData,
+      searchParams,
+      QUERY_PARAMS,
+    );
+
+    if (newParams.toString() !== searchParams.toString()) {
+      setSearchParams(newParams);
+    }
+  };
+
+  return (
+    <>
+      <h2 className="u-off-screen">Search and filter</h2>
+      <SearchAndFilter
+        filterPanelData={searchAndFilterData}
+        returnSearchData={onSearchDataChange}
+      />
+    </>
+  );
+};
+
+export default memo(ClusterSearchFilter);

--- a/ui/src/pages/clusters/metrics/ClusterDiskGraph.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterDiskGraph.tsx
@@ -1,15 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
-import { fetchClusters } from "api/clusters";
 import PercentileChart from "components/PercentileChart";
 import { FC } from "react";
-import { queryKeys } from "util/queryKeys";
+import { Cluster } from "types/cluster";
 
-const ClusterDiskGraph: FC = () => {
-  const { data: clusters = [] } = useQuery({
-    queryKey: [queryKeys.clusters],
-    queryFn: fetchClusters,
-  });
+interface Props {
+  clusters: Cluster[];
+}
 
+const ClusterDiskGraph: FC<Props> = ({ clusters }) => {
   const diskUsagePercentages = clusters.map(
     (cluster) => cluster.disk_usage / cluster.disk_total_size || 0,
   );

--- a/ui/src/pages/clusters/metrics/ClusterMemoryGraph.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterMemoryGraph.tsx
@@ -1,15 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
-import { fetchClusters } from "api/clusters";
 import PercentileChart from "components/PercentileChart";
 import { FC } from "react";
-import { queryKeys } from "util/queryKeys";
+import { Cluster } from "types/cluster";
 
-const ClusterMemoryGraph: FC = () => {
-  const { data: clusters = [] } = useQuery({
-    queryKey: [queryKeys.clusters],
-    queryFn: fetchClusters,
-  });
+interface Props {
+  clusters: Cluster[];
+}
 
+const ClusterMemoryGraph: FC<Props> = ({ clusters }) => {
   const memoryUsagePercentages = clusters.map(
     (cluster) => cluster.memory_usage / cluster.memory_total_amount || 0,
   );

--- a/ui/src/pages/clusters/metrics/ClusterStatusGraph.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterStatusGraph.tsx
@@ -1,17 +1,14 @@
 import { Icon } from "@canonical/react-components";
-import { useQuery } from "@tanstack/react-query";
-import { fetchClusters } from "api/clusters";
 import DoughnutChart from "components/DoughnutChart";
 import { FC, ReactNode } from "react";
+import { Cluster } from "types/cluster";
 import { getMinutesSinceLastHeartbeat } from "util/helpers";
-import { queryKeys } from "util/queryKeys";
 
-const ClusterStatusGraph: FC = () => {
-  const { data: clusters = [] } = useQuery({
-    queryKey: [queryKeys.clusters],
-    queryFn: fetchClusters,
-  });
+interface Props {
+  clusters: Cluster[];
+}
 
+const ClusterStatusGraph: FC<Props> = ({ clusters }) => {
   const totalClusters = clusters.length;
   const activeClusters = clusters.filter(
     (cluster) =>

--- a/ui/src/sass/_page_header.scss
+++ b/ui/src/sass/_page_header.scss
@@ -1,0 +1,39 @@
+.page-header {
+  display: flex;
+  padding: $spv--x-small $sph--x-large calc($spv--small - 1px) $sph--x-large;
+
+  .page-header__left {
+    display: flex;
+    flex: 2;
+
+    h1 {
+      margin-right: 2rem;
+    }
+
+    .page-header__search {
+      margin-bottom: 3.5px !important; // to align with the selected item state
+      max-width: 35vw;
+      width: 100%;
+    }
+
+    .p-search-and-filter__panel {
+      min-width: 100%;
+      width: 45vw;
+    }
+  }
+
+  .page-header__base-actions {
+    align-self: flex-start;
+    flex: 1;
+  }
+}
+
+.l-navigation.is-collapsed + .page-header {
+  .page-header__search {
+    width: 50vw;
+  }
+
+  .p-search-and-filter__panel {
+    width: 130% !important;
+  }
+}

--- a/ui/src/sass/styles.scss
+++ b/ui/src/sass/styles.scss
@@ -24,6 +24,7 @@
 @import "doughnut_chart";
 @import "forms";
 @import "meter";
+@import "page_header";
 @import "pattern_navigation";
 @import "percentile_chart";
 @import "scrollable_container";

--- a/ui/src/types/cluster.d.ts
+++ b/ui/src/types/cluster.d.ts
@@ -29,3 +29,9 @@ export interface MultiMeterValue {
   status: string;
   color: string;
 }
+
+export type ClusterInstanceStatus = "Running" | "Frozen" | "Error" | "Stopped";
+
+export type ClusterNodeStatus = "Online" | "Blocked" | "Offline" | "Evacuated";
+
+export type ClusterPercentiles = 0.5 | 0.75 | 0.8 | 0.9;

--- a/ui/src/util/clusterFilter.tsx
+++ b/ui/src/util/clusterFilter.tsx
@@ -1,0 +1,74 @@
+import {
+  ClusterInstanceStatus,
+  ClusterNodeStatus,
+  ClusterPercentiles,
+  StatusDistribution,
+} from "types/cluster";
+
+export interface ClusterFilters {
+  queries: string[];
+  instanceStatuses: ClusterInstanceStatus[];
+  nodeStatuses: ClusterNodeStatus[];
+  memoryUsage: number[];
+  diskUsage: number[];
+}
+
+export const instanceStatuses: ClusterInstanceStatus[] = [
+  "Running",
+  "Stopped",
+  "Frozen",
+  "Error",
+];
+
+export const nodeStatuses: ClusterNodeStatus[] = [
+  "Online",
+  "Blocked",
+  "Offline",
+  "Evacuated",
+];
+
+export const usagePercentiles = [">50%", ">75%", ">80%", ">90%"];
+
+export const toNumericUsagePercentiles = (percentiles: string[]): number[] => {
+  const enrichedUsages = [] as ClusterPercentiles[];
+
+  if (percentiles.includes(">50%")) {
+    enrichedUsages.push(0.5);
+  }
+  if (percentiles.includes(">75%")) {
+    enrichedUsages.push(0.75);
+  }
+  if (percentiles.includes(">80%")) {
+    enrichedUsages.push(0.8);
+  }
+  if (percentiles.includes(">90%")) {
+    enrichedUsages.push(0.9);
+  }
+
+  return enrichedUsages;
+};
+
+export const hasAllMatchingStatuses = (
+  filteredStatuses: string[],
+  itemStatuses: StatusDistribution[],
+) => {
+  const filterStatusCountLookup: { [status: string]: number } = {};
+
+  itemStatuses.forEach((item) => {
+    filterStatusCountLookup[item.status] = item.count;
+  });
+
+  return filteredStatuses.every(
+    (status) => filterStatusCountLookup[status] > 0,
+  );
+};
+
+export const hasAllUsagePercentileBands = (
+  usagePercentileBands: number[],
+  use: number,
+  total: number,
+) => {
+  const usagePercentage = use / total;
+
+  return usagePercentileBands.every((num) => usagePercentage >= num);
+};

--- a/ui/src/util/searchAndFilter.tsx
+++ b/ui/src/util/searchAndFilter.tsx
@@ -1,0 +1,47 @@
+import { SearchAndFilterChip } from "@canonical/react-components/dist/components/SearchAndFilter/types";
+
+export const paramsFromSearchData = (
+  searchData: SearchAndFilterChip[],
+  searchParams: URLSearchParams,
+  queryParams: string[],
+): URLSearchParams => {
+  const newParams = new URLSearchParams(searchParams.toString());
+
+  queryParams.forEach((param) => {
+    newParams.delete(param);
+    searchValuesByLead(searchData, param).forEach((value) =>
+      newParams.append(param, value),
+    );
+  });
+
+  return newParams;
+};
+
+const searchValuesByLead = (
+  searchData: SearchAndFilterChip[],
+  lead: string,
+): string[] =>
+  searchData
+    .filter(
+      (chip) => chip.lead === lead || (lead === "query" && chip.quoteValue),
+    )
+    .map((chip) => chip.value);
+
+export const searchParamsToChips = (
+  searchParams: URLSearchParams,
+  queryParams: string[],
+): SearchAndFilterChip[] => {
+  const searchData: SearchAndFilterChip[] = [];
+  queryParams.forEach((param) =>
+    searchData.push(
+      ...searchParams
+        .getAll(param)
+        .map((value) =>
+          param === "query"
+            ? { quoteValue: true, value }
+            : { lead: param, value },
+        ),
+    ),
+  );
+  return searchData;
+};


### PR DESCRIPTION
Work done:
- Implemeneted Custom Layout
- Implemented Pageheader component
- Implemented ClusterSearchFilter component alongside all relevant types
- Added ClusterSearchFilter to ClusterList
- Added Search Logic and Filter Logic
- Added scss styling for the page header.
- Minor other scss changes for consistency

Notes:
- Amended generate_cluster script so that it generates null (0) values for some of the clusters, for testing purposes. Whilst you can filter by statuses, this was not initially available in the UI. To counter this, I amended the generate_cluster script such that there became a way for "Running" instance statuses and "Online" Node statuses to be 0. Now, we can filter by those two statuses (for testing).

![image](https://github.com/user-attachments/assets/38c6bae3-b115-4f60-96a9-373607896453)

![image](https://github.com/user-attachments/assets/33baa6c3-eac5-4c0e-915c-969e17ba396d)

![image](https://github.com/user-attachments/assets/9d89cc3d-8f37-4a0b-b35c-e7369e0ecea7)
- ^ Filter by Memory where Memory is >90%.
- Note the change in URL params.

![image](https://github.com/user-attachments/assets/a69545c5-e850-4916-90d0-986adca873c5)
- ^ Filter by Memory where Memory is >90% and Node status is online.
