### PR TITLE
fix: golangci-lint now checks for constant input for format strings

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.22.5
 
       - name: Install Dotrun
         run: |

--- a/test/helpers/client.go
+++ b/test/helpers/client.go
@@ -199,7 +199,7 @@ func parseResponse(resp *http.Response) (*api.Response, error) {
 
 	// Handle errors
 	if response.Type == api.ErrorResponse {
-		return nil, api.StatusErrorf(resp.StatusCode, response.Error)
+		return nil, api.StatusErrorf(resp.StatusCode, "%s", response.Error)
 	}
 
 	return &response, nil

--- a/ui/tests/setup/auth.setup.ts
+++ b/ui/tests/setup/auth.setup.ts
@@ -4,10 +4,10 @@ import { authFile } from "../fixtures/constants";
 const loginUser = async (page: Page, sso: boolean) => {
   await page.getByRole("link", { name: "Login" }).click();
   if (sso) {
-    await page.getByLabel("Email address*").click();
-    await page.getByLabel("Email address*").fill(process.env.OIDC_USER || "");
-    await page.getByLabel("Password*").click();
-    await page.getByLabel("Password*").fill(process.env.OIDC_PASSWORD || "");
+    await page.getByLabel("Email address").click();
+    await page.getByLabel("Email address").fill(process.env.OIDC_USER || "");
+    await page.getByLabel("Password").click();
+    await page.getByLabel("Password").fill(process.env.OIDC_PASSWORD || "");
     await page.getByRole("button", { name: "Continue", exact: true }).click();
   }
   await expect(page.getByText("Log out")).toBeVisible();


### PR DESCRIPTION
## Done
- fix linting error due to `golangci-lint` now checks for constant input for format strings
- auth0 may have changed their login screen input labels causing login e2e to fail. This is fixed here as well.