### PR TITLE
fix: allow oidc client to use hostname of provider for certificate validation

### DIFF
--- a/cmd/management-api/management-api.go
+++ b/cmd/management-api/management-api.go
@@ -63,7 +63,6 @@ func Run() (err error) {
 		cfg.OIDCClientID,
 		cfg.OIDCAudience,
 		cfg.ManagementAPICert,
-		cfg.Version == "development",
 	)
 
 	if err != nil {

--- a/internal/app/management-api/core/auth/oidc.go
+++ b/internal/app/management-api/core/auth/oidc.go
@@ -495,7 +495,7 @@ func (o *Verifier) Host() string {
 }
 
 // NewVerifier returns a Verifier.
-func NewVerifier(issuer string, clientID string, audience string, cert *shared.CertInfo, isDev bool) (*Verifier, error) {
+func NewVerifier(issuer string, clientID string, audience string, cert *shared.CertInfo) (*Verifier, error) {
 	// Setup a http client for communicating with the OIDC provider.
 	httpClientFunc := func() (*http.Client, error) {
 		client, err := util.HTTPClient("", http.ProxyFromEnvironment)
@@ -510,15 +510,11 @@ func NewVerifier(issuer string, clientID string, audience string, cert *shared.C
 		}
 
 		newTransport := existingTransport.Clone()
-		clientTLSConfig, err := shared.GetTLSConfig(cert.CA())
+		clientTLSConfig, err := shared.GetTLSConfig(nil)
 		if err != nil {
 			return nil, err
 		}
 
-		// TODO: see if it's possible to overcome this even locally
-		if isDev {
-			clientTLSConfig.InsecureSkipVerify = true
-		}
 		newTransport.TLSClientConfig = clientTLSConfig
 		client.Transport = newTransport
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -24,6 +24,11 @@ services:
 
 # dependencies
 parts:
+  certificates:
+    plugin: nil
+    stage-packages:
+      - ca-certificates
+
   app-build:
     plugin: go
     source: .
@@ -41,4 +46,4 @@ parts:
     organize:
       opt/lxd-cluster-manager/bin/app: usr/bin/lxd-cluster-manager
     stage-packages:
-      - base-files_var # TODO: figure out what this is for, referenced admin UI
+      - base-files_var


### PR DESCRIPTION
##Done

- Construct oidc client to use provider hostname for certificate validation