### PR TITLE
feat improve seeding to be more realistic, adjust color scheme to be more serious

### DIFF
--- a/internal/pkg/database/seed/seed.go
+++ b/internal/pkg/database/seed/seed.go
@@ -151,13 +151,33 @@ func seedRemoteClusterTokens(ctx context.Context, db *database.DB) error {
 	})
 }
 
+func generateCounts(maxCount int) (int, int, int, int) {
+	if rand.Float64() < 0.5 {
+		// 50% chance: count1 == maxCount, others are 0
+		return maxCount, 0, 0, 0
+	}
+
+	// 50% chance: count1 ~ 80% of maxCount
+	percentage := rand.Float64()*0.1 + 0.75 // random between 0.75 and 0.85
+	count1 := int(float64(maxCount) * percentage)
+	remaining := maxCount - count1
+
+	// Randomly divide remaining into 3 parts
+	r1 := rand.Float64()
+	r2 := rand.Float64()
+	r3 := rand.Float64()
+	total := r1 + r2 + r3
+
+	count2 := int(float64(remaining) * r1 / total)
+	count3 := int(float64(remaining) * r2 / total)
+	count4 := remaining - count2 - count3 // ensure total sum == maxCount
+
+	return count1, count2, count3, count4
+}
+
 // generateRandomStatuses generates a JSON array of statuses with random counts.
 func generateRandomStatuses(status1, status2, status3, status4 string, maxCount int) []byte {
-	// Generate random values for the first three statuses
-	count1 := rand.IntN(maxCount / 2) // Max is half to balance distribution
-	count2 := rand.IntN(maxCount - count1)
-	count3 := rand.IntN(maxCount - count1 - count2)
-	count4 := maxCount - count1 - count2 - count3
+	count1, count2, count3, count4 := generateCounts(maxCount)
 
 	statuses := []map[string]any{
 		{"status": status1, "count": count1},
@@ -175,12 +195,14 @@ func generateRemoteClusterDetails(count int) []store.RemoteClusterDetail {
 	clusters := make([]store.RemoteClusterDetail, count)
 
 	for i := 0; i < count; i++ {
-		totalMemory := (rand.IntN(16) + 1) * 1024 // Random memory in multiples of 1024
-		memoryUsage := rand.IntN(totalMemory + 1)
-		totalDisk := (rand.IntN(200) + 1) * 1000 // Random disk size in multiples of 1000
-		diskUsage := rand.IntN(totalDisk + 1)
-		totalInstances := rand.IntN(50) + 2
-		totalMembers := rand.IntN(20) + 2
+		totalMemory := (rand.IntN(16) + 1) * 32 * 1024 * 1024 * 1024 // Random memory in multiples of 1024
+		quarterMemory := totalMemory / 4
+		memoryUsage := quarterMemory + rand.IntN(quarterMemory+1)    // max half and minimum a quarter of memory is used
+		totalDisk := (rand.IntN(200) + 1) * 100 * 1024 * 1024 * 1024 // Random disk size in multiples of 1000
+		halfDisk := totalDisk / 2
+		diskUsage := rand.IntN(halfDisk + 1) // max half the disk is used
+		totalInstances := rand.IntN(50) + 6
+		totalMembers := rand.IntN(20) + 6
 
 		clusters[i] = store.RemoteClusterDetail{
 			RemoteClusterID:   i + 1,

--- a/ui/src/components/PercentileChart.tsx
+++ b/ui/src/components/PercentileChart.tsx
@@ -17,7 +17,6 @@ const PercentileChart: FC<Props> = ({
   height,
   barClassName,
 }) => {
-  const maxDataValue = Math.max(...data);
   const barWidth = height / data.length;
 
   return (
@@ -44,7 +43,7 @@ const PercentileChart: FC<Props> = ({
             x={0}
             // Add 0.5 to the height to prevent gaps between the bars
             height={barWidth + 0.5}
-            width={(dataPoint / maxDataValue) * width}
+            width={dataPoint * width}
             className={barClassName}
           />
         ))}

--- a/ui/src/pages/clusters/ClusterListActive.tsx
+++ b/ui/src/pages/clusters/ClusterListActive.tsx
@@ -23,10 +23,6 @@ const ClusterListActive: FC<Props> = ({ clusters, isLoading }) => {
       sortKey: "name",
     },
     {
-      content: "Status",
-      sortKey: "status",
-    },
-    {
       content: "Last Heartbeat",
       sortKey: "lastHeartbeat",
     },
@@ -45,6 +41,10 @@ const ClusterListActive: FC<Props> = ({ clusters, isLoading }) => {
     {
       content: "Disk",
     },
+    {
+      content: "Status",
+      sortKey: "status",
+    },
   ];
 
   const tableRows = clusters.map((cluster) => {
@@ -55,7 +55,6 @@ const ClusterListActive: FC<Props> = ({ clusters, isLoading }) => {
             <Link to={`/ui/cluster/${cluster.name}`}>{cluster.name}</Link>
           ),
         },
-        { content: <ClusterStatus cluster={cluster} /> },
         { content: <ClusterHeartbeat cluster={cluster} /> },
         {
           content: <ClusterMembers cluster={cluster} />,
@@ -72,6 +71,7 @@ const ClusterListActive: FC<Props> = ({ clusters, isLoading }) => {
         {
           content: <ClusterDisk cluster={cluster} />,
         },
+        { content: <ClusterStatus cluster={cluster} /> },
       ],
       sortData: {
         name: cluster.name,

--- a/ui/src/pages/clusters/metrics/ClusterCpu.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterCpu.tsx
@@ -17,24 +17,10 @@ export const ClusterCpu: FC<Props> = ({
     cluster.cpu_load_15,
   ];
 
-  const getStyle = (reading: number) => {
-    if (reading <= 0.6) {
-      return "129, 70, 186";
-    } else {
-      return "199, 22, 43";
-    }
-  };
-
   return (
     <div className={classnames("cpu-badges", containerClassname)}>
       {averageReadings.map((reading, index) => (
-        <div
-          key={index}
-          className={"cpu-badge"}
-          style={{
-            backgroundColor: `rgba(${getStyle(parseFloat(reading))}, ${parseFloat(reading)})`,
-          }}
-        >
+        <div key={index} className={"cpu-badge"}>
           {reading}
         </div>
       ))}

--- a/ui/src/pages/clusters/metrics/ClusterDiskGraph.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterDiskGraph.tsx
@@ -15,7 +15,7 @@ const ClusterDiskGraph: FC<Props> = ({ clusters }) => {
 
   return (
     <PercentileChart
-      title="Disk usage"
+      title="Disk usage in %"
       barClassName="cluster-disk-bar"
       data={diskUsagePercentages}
       width={200}

--- a/ui/src/pages/clusters/metrics/ClusterInstances.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterInstances.tsx
@@ -50,6 +50,12 @@ export const ClusterInstances: FC<Props> = ({ cluster }: Props) => {
     },
   ];
 
+  const notOkCount = total - runningInstances.count;
+  const extra =
+    notOkCount > 0
+      ? `(${total - runningInstances.count} not running)`
+      : "running";
+
   return (
     <Tooltip
       message={
@@ -75,10 +81,7 @@ export const ClusterInstances: FC<Props> = ({ cluster }: Props) => {
       positionElementClassName="tooltip"
       position="btm-center"
     >
-      <MultiMeter
-        values={values}
-        text={`${total} ( ${total - runningInstances.count} not running)`}
-      />
+      <MultiMeter values={values} text={`${total} ${extra}`} />
     </Tooltip>
   );
 };

--- a/ui/src/pages/clusters/metrics/ClusterMembers.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterMembers.tsx
@@ -50,6 +50,10 @@ export const ClusterMembers: FC<Props> = ({ cluster }: Props) => {
     },
   ];
 
+  const notOkCount = total - onlineMembers.count;
+  const extra =
+    notOkCount > 0 ? `(${total - onlineMembers.count} degraded)` : "online";
+
   return (
     <Tooltip
       message={
@@ -75,10 +79,7 @@ export const ClusterMembers: FC<Props> = ({ cluster }: Props) => {
       positionElementClassName="tooltip"
       position="btm-center"
     >
-      <MultiMeter
-        values={values}
-        text={`${total} ( ${total - onlineMembers.count} degraded)`}
-      />
+      <MultiMeter values={values} text={`${total} ${extra}`} />
     </Tooltip>
   );
 };

--- a/ui/src/pages/clusters/metrics/ClusterMemoryGraph.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterMemoryGraph.tsx
@@ -15,7 +15,7 @@ const ClusterMemoryGraph: FC<Props> = ({ clusters }) => {
 
   return (
     <PercentileChart
-      title="Memory usage"
+      title="Memory usage in %"
       barClassName="cluster-memory-bar"
       data={memoryUsagePercentages}
       width={200}

--- a/ui/src/sass/_clustercpu.scss
+++ b/ui/src/sass/_clustercpu.scss
@@ -4,6 +4,7 @@
   margin: auto;
 
   .cpu-badge {
+    background-color: $cpu-color;
     border-radius: 15px;
     margin: 5px;
     padding: 5px 10px;

--- a/ui/src/sass/_colors.scss
+++ b/ui/src/sass/_colors.scss
@@ -1,4 +1,4 @@
 $instance-color: #0e8420;
-$cpu-color: #8146ba;
-$memory-color: #b04000;
+$cpu-color: #eee;
+$memory-color: #06c;
 $disk-color: #06c;


### PR DESCRIPTION
# Done
- improve seeding to be more realistic:  
    - member + instance statuses online or off
     - memory and disk more in ~50% range
- adjust color scheme to be more serious
 - move status to last column
 - make the disk and memory graph span scale properly

![image](https://github.com/user-attachments/assets/bea40419-2aae-489a-b66c-ea4822291864)
