### PR TITLE
feat(cluster) more text heavy cluster list page

### DIFF
--- a/ui/src/components/Meter.tsx
+++ b/ui/src/components/Meter.tsx
@@ -18,7 +18,7 @@ const Meter: FC<Props> = ({
       <div className="p-meter u-no-margin--bottom">
         <div className={type} style={{ width: `${percentage}%` }} />
       </div>
-      <p className="p-text--small u-no-margin--bottom">{text}</p>
+      <div className="u-text--muted u-no-margin--bottom">{text}</div>
     </div>
   );
 };

--- a/ui/src/components/MultiMeter.tsx
+++ b/ui/src/components/MultiMeter.tsx
@@ -32,7 +32,7 @@ const MultiMeter: FC<Props> = ({ values, text }) => {
           );
         })}
       </div>
-      <p className="p-text--small u-no-margin--bottom">{text}</p>
+      <div className="u-text--muted u-no-margin--bottom">{text}</div>
     </>
   );
 };

--- a/ui/src/pages/clusters/AddClusterButton.tsx
+++ b/ui/src/pages/clusters/AddClusterButton.tsx
@@ -1,4 +1,4 @@
-import { ActionButton } from "@canonical/react-components";
+import { ActionButton, Icon } from "@canonical/react-components";
 import { FC } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -11,9 +11,10 @@ const AddClusterButton: FC = () => {
         void navigate("/ui/clusters/create");
       }}
       appearance="positive"
-      className="u-float-right u-no-margin--bottom"
+      className="u-float-right u-no-margin--bottom has-icon"
     >
-      Add New Cluster
+      <Icon name="plus" light />
+      <span>Enrol cluster</span>
     </ActionButton>
   );
 };

--- a/ui/src/pages/clusters/ClusterDetail.tsx
+++ b/ui/src/pages/clusters/ClusterDetail.tsx
@@ -6,7 +6,7 @@ import React, { FC } from "react";
 import { Link, useParams } from "react-router-dom";
 import { queryKeys } from "util/queryKeys";
 import ClusterDetailInstanceGraph from "./metrics/ClusterDetailInstanceGraph";
-import ClusterDetailNodeGraph from "./metrics/ClusterDetailNodeGraph";
+import ClusterDetailMemberGraph from "./metrics/ClusterDetailMemberGraph";
 import ClusterTimer from "./metrics/ClusterTimer";
 import ClusterDetailMetrics from "./metrics/ClusterDetailMetrics";
 import Loader from "components/Loader";
@@ -14,6 +14,7 @@ import BreadCrumbHeader from "components/BreadcrumbHeader";
 import DeleteClusterButton from "pages/clusters/DeleteClusterButton";
 import ClusterMetricsButton from "pages/clusters/ClusterMetricsButton";
 import ClusterUiButton from "pages/clusters/ClusterUiButton";
+import { ClusterWarningList } from "pages/clusters/metrics/ClusterWarningList";
 
 const ClusterDetail: FC = () => {
   const { name } = useParams<{ name: string }>();
@@ -31,6 +32,10 @@ const ClusterDetail: FC = () => {
     refetchInterval: 60000,
     refetchIntervalInBackground: true,
   });
+
+  if (isLoading) {
+    return <></>;
+  }
 
   if (!cluster) {
     return <>Unable to get details</>;
@@ -78,7 +83,7 @@ const ClusterDetail: FC = () => {
                 cluster={cluster}
                 key="cluster-detail-metrics"
               />,
-              <ClusterDetailNodeGraph
+              <ClusterDetailMemberGraph
                 cluster={cluster}
                 key="cluster-node-graph"
               />,
@@ -88,6 +93,7 @@ const ClusterDetail: FC = () => {
               />,
             ]}
           />
+          <ClusterWarningList cluster={cluster} />
         </Row>
       )}
     </BaseLayout>

--- a/ui/src/pages/clusters/ClusterList.tsx
+++ b/ui/src/pages/clusters/ClusterList.tsx
@@ -1,14 +1,11 @@
 import { FC } from "react";
-import { List, Row } from "@canonical/react-components";
+import { Row } from "@canonical/react-components";
 import { useParams, useSearchParams } from "react-router-dom";
 import TabLinks from "components/TabLinks";
 import ClusterListTokens from "./ClusterListTokens";
 import ClusterListActive from "./ClusterListActive";
 import AddClusterButton from "./AddClusterButton";
-import ClusterStatusGraph from "./metrics/ClusterStatusGraph";
 import NotificationRow from "components/NotificationRow";
-import ClusterDiskGraph from "./metrics/ClusterDiskGraph";
-import ClusterMemoryGraph from "./metrics/ClusterMemoryGraph";
 import ClusterSearchFilter from "pages/clusters/ClusterSearchFilter";
 import CustomLayout from "components/CustomLayout";
 import PageHeader from "components/PageHeader";
@@ -125,24 +122,6 @@ const ClusterList: FC = () => {
       }
     >
       <Row>
-        <List
-          className="cluster-graphs"
-          inline
-          items={[
-            <ClusterStatusGraph
-              key="cluster-status-graph"
-              clusters={filteredClusters}
-            />,
-            <ClusterDiskGraph
-              key="cluster-disk-graph"
-              clusters={filteredClusters}
-            />,
-            <ClusterMemoryGraph
-              key="cluster-memory-graph"
-              clusters={filteredClusters}
-            />,
-          ]}
-        />
         <TabLinks tabs={tabs} activeTab={activeTab} tabUrl="/ui/clusters" />
         <NotificationRow />
         <div>

--- a/ui/src/pages/clusters/ClusterListActive.tsx
+++ b/ui/src/pages/clusters/ClusterListActive.tsx
@@ -1,15 +1,13 @@
-import { FC } from "react";
+import React, { FC } from "react";
 import { MainTable, TablePagination } from "@canonical/react-components";
 import Loader from "components/Loader";
 import { Link } from "react-router-dom";
 import { ClusterInstances } from "./metrics/ClusterInstances";
-import { ClusterCpu } from "./metrics/ClusterCpu";
-import { ClusterMemory } from "./metrics/ClusterMemory";
-import { ClusterDisk } from "./metrics/ClusterDisk";
 import { ClusterMembers } from "./metrics/ClusterMembers";
 import ClusterHeartbeat from "./metrics/ClusterHeartbeat";
 import ClusterStatus from "./metrics/ClusterStatus";
 import { Cluster } from "types/cluster";
+import { ClusterWarningCount } from "pages/clusters/metrics/ClusterWarningCount";
 
 type Props = {
   clusters: Cluster[];
@@ -23,23 +21,13 @@ const ClusterListActive: FC<Props> = ({ clusters, isLoading }) => {
       sortKey: "name",
     },
     {
-      content: "Last Heartbeat",
-      sortKey: "lastHeartbeat",
-    },
-    {
       content: "Members",
     },
     {
-      content: "Instances",
+      content: "Instances running",
     },
     {
-      content: "CPU",
-    },
-    {
-      content: "Memory",
-    },
-    {
-      content: "Disk",
+      content: "Warnings",
     },
     {
       content: "Status",
@@ -55,7 +43,6 @@ const ClusterListActive: FC<Props> = ({ clusters, isLoading }) => {
             <Link to={`/ui/cluster/${cluster.name}`}>{cluster.name}</Link>
           ),
         },
-        { content: <ClusterHeartbeat cluster={cluster} /> },
         {
           content: <ClusterMembers cluster={cluster} />,
         },
@@ -63,15 +50,16 @@ const ClusterListActive: FC<Props> = ({ clusters, isLoading }) => {
           content: <ClusterInstances cluster={cluster} />,
         },
         {
-          content: <ClusterCpu cluster={cluster} />,
+          content: <ClusterWarningCount cluster={cluster} />,
         },
         {
-          content: <ClusterMemory cluster={cluster} />,
+          content: (
+            <>
+              <ClusterStatus cluster={cluster} />
+              <ClusterHeartbeat cluster={cluster} />
+            </>
+          ),
         },
-        {
-          content: <ClusterDisk cluster={cluster} />,
-        },
-        { content: <ClusterStatus cluster={cluster} /> },
       ],
       sortData: {
         name: cluster.name,

--- a/ui/src/pages/clusters/metrics/ClusterDetailInstanceGraph.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterDetailInstanceGraph.tsx
@@ -2,7 +2,7 @@ import { Icon } from "@canonical/react-components";
 import DoughnutChart from "components/DoughnutChart";
 import { FC, ReactNode } from "react";
 import { Cluster } from "types/cluster";
-import { statusCount } from "util/helpers";
+import { pluralizeWord, statusCount } from "util/helpers";
 
 interface Props {
   cluster: Cluster;
@@ -52,7 +52,7 @@ const ClusterDetailInstanceGraph: FC<Props> = ({ cluster }: Props) => {
       />
       <ul className="doughnut-chart__legend u-no-margin--left">
         <li className="u-no-margin p-heading--5 u-no-padding">
-          {totalInstances} Instances
+          {totalInstances} {pluralizeWord("instance", totalInstances)}
         </li>
         <li>
           <Icon name="status-succeeded-small" />

--- a/ui/src/pages/clusters/metrics/ClusterDetailMemberGraph.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterDetailMemberGraph.tsx
@@ -2,13 +2,13 @@ import { Icon } from "@canonical/react-components";
 import DoughnutChart from "components/DoughnutChart";
 import { FC, ReactNode } from "react";
 import { Cluster } from "types/cluster";
-import { statusCount } from "util/helpers";
+import { pluralizeWord, statusCount } from "util/helpers";
 
 interface Props {
   cluster: Cluster;
 }
 
-const ClusterDetailNodeGraph: FC<Props> = ({ cluster }: Props) => {
+const ClusterDetailMemberGraph: FC<Props> = ({ cluster }: Props) => {
   const onlineMembers = statusCount(cluster.member_statuses, "Online");
   const offlineMembers = statusCount(cluster.member_statuses, "Offline");
   const evacuatedMembers = statusCount(cluster.member_statuses, "Evacuated");
@@ -56,7 +56,7 @@ const ClusterDetailNodeGraph: FC<Props> = ({ cluster }: Props) => {
       />
       <ul className="doughnut-chart__legend u-no-margin--left">
         <li className="u-no-margin p-heading--5 u-no-padding">
-          {totalMembers} Members
+          {totalMembers} {pluralizeWord("member", totalMembers)}
         </li>
         <li>
           <Icon name="status-succeeded-small" />
@@ -82,4 +82,4 @@ const ClusterDetailNodeGraph: FC<Props> = ({ cluster }: Props) => {
   );
 };
 
-export default ClusterDetailNodeGraph;
+export default ClusterDetailMemberGraph;

--- a/ui/src/pages/clusters/metrics/ClusterDetailMetrics.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterDetailMetrics.tsx
@@ -1,5 +1,4 @@
 import { Cluster } from "types/cluster";
-import { ClusterCpu } from "./ClusterCpu";
 import { ClusterMemory } from "./ClusterMemory";
 import { ClusterDisk } from "./ClusterDisk";
 import { FC } from "react";
@@ -13,13 +12,7 @@ const ClusterDetailMetrics: FC<Props> = ({ cluster }: Props) => {
     <div className="cluster-detail-metrics">
       <div className="meter-row">
         <span className="meter-row__title u-no-margin p-heading--5 u-no-padding">
-          CPU
-        </span>
-        <ClusterCpu cluster={cluster} containerClassname="meter-row__metrics" />
-      </div>
-      <div className="meter-row">
-        <span className="meter-row__title u-no-margin p-heading--5 u-no-padding">
-          Memory
+          Total memory
         </span>
         <ClusterMemory
           cluster={cluster}
@@ -28,7 +21,7 @@ const ClusterDetailMetrics: FC<Props> = ({ cluster }: Props) => {
       </div>
       <div className="meter-row">
         <span className="meter-row__title u-no-margin p-heading--5 u-no-padding">
-          Disk
+          Total storage
         </span>
         <ClusterDisk
           cluster={cluster}

--- a/ui/src/pages/clusters/metrics/ClusterHeartbeat.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterHeartbeat.tsx
@@ -12,20 +12,23 @@ const ClusterHeartbeat: FC<Props> = ({ cluster }: Props) => {
   let returnStr;
 
   if (lastHeartbeatMins <= 1) {
-    returnStr = `< 1 minute ago`;
+    returnStr = `seen 1 minute ago`;
   } else if (lastHeartbeatMins < 5) {
-    returnStr = `${lastHeartbeatMins} minutes ago`;
+    returnStr = `seen ${lastHeartbeatMins} minutes ago`;
   } else {
     returnStr =
       lastHeartbeatHrs < 1 //Displayed for "Last Seen"'s of 5-59 Minutes
-        ? `< 1 hour ago`
+        ? `seen in last hour`
         : lastHeartbeatHrs < 2
-          ? `1 hour ago`
-          : `${lastHeartbeatHrs} hours ago`;
+          ? `seen 1 hour ago`
+          : `seen ${lastHeartbeatHrs} hours ago`;
   }
 
   return (
-    <div title={isoTimeToString(cluster.last_status_update_at)}>
+    <div
+      title={isoTimeToString(cluster.last_status_update_at)}
+      className="u-text--muted"
+    >
       {returnStr}
     </div>
   );

--- a/ui/src/pages/clusters/metrics/ClusterInstances.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterInstances.tsx
@@ -1,6 +1,5 @@
 import { FC } from "react";
 import { Cluster } from "types/cluster";
-import MultiMeter from "components/MultiMeter";
 import { Icon, Tooltip } from "@canonical/react-components";
 
 interface Props {
@@ -20,41 +19,6 @@ export const ClusterInstances: FC<Props> = ({ cluster }: Props) => {
   const errorInstances = cluster.instance_statuses.find(
     (item) => item.status === "Error",
   ) ?? { count: 0 };
-
-  const total =
-    runningInstances.count +
-    stoppedInstances.count +
-    frozenInstances.count +
-    errorInstances.count;
-
-  const values = [
-    {
-      amount: runningInstances.count,
-      status: "Running",
-      color: "#0E8420",
-    },
-    {
-      amount: frozenInstances.count,
-      status: "Frozen",
-      color: "#24598f",
-    },
-    {
-      amount: errorInstances.count,
-      status: "Error",
-      color: "#C7162B",
-    },
-    {
-      amount: stoppedInstances.count,
-      status: "Stopped",
-      color: "#000",
-    },
-  ];
-
-  const notOkCount = total - runningInstances.count;
-  const extra =
-    notOkCount > 0
-      ? `(${total - runningInstances.count} not running)`
-      : "running";
 
   return (
     <Tooltip
@@ -79,9 +43,9 @@ export const ClusterInstances: FC<Props> = ({ cluster }: Props) => {
         </div>
       }
       positionElementClassName="tooltip"
-      position="btm-center"
+      position="left"
     >
-      <MultiMeter values={values} text={`${total} ${extra}`} />
+      <div className="u-pointer">{runningInstances.count}</div>
     </Tooltip>
   );
 };

--- a/ui/src/pages/clusters/metrics/ClusterMembers.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterMembers.tsx
@@ -1,5 +1,4 @@
 import { Icon, Tooltip } from "@canonical/react-components";
-import MultiMeter from "components/MultiMeter";
 import { FC } from "react";
 import { Cluster } from "types/cluster";
 
@@ -27,33 +26,6 @@ export const ClusterMembers: FC<Props> = ({ cluster }: Props) => {
     evacuatedMembers.count +
     blockedMembers.count;
 
-  const values = [
-    {
-      amount: onlineMembers.count,
-      status: "Online",
-      color: "#0E8420",
-    },
-    {
-      amount: blockedMembers.count,
-      status: "Blocked",
-      color: "#CC7900",
-    },
-    {
-      amount: offlineMembers.count,
-      status: "Offline",
-      color: "#C7162B",
-    },
-    {
-      amount: evacuatedMembers.count,
-      status: "Evacuated",
-      color: "#000",
-    },
-  ];
-
-  const notOkCount = total - onlineMembers.count;
-  const extra =
-    notOkCount > 0 ? `(${total - onlineMembers.count} degraded)` : "online";
-
   return (
     <Tooltip
       message={
@@ -77,9 +49,9 @@ export const ClusterMembers: FC<Props> = ({ cluster }: Props) => {
         </div>
       }
       positionElementClassName="tooltip"
-      position="btm-center"
+      position="left"
     >
-      <MultiMeter values={values} text={`${total} ${extra}`} />
+      <div className="u-pointer">{total}</div>
     </Tooltip>
   );
 };

--- a/ui/src/pages/clusters/metrics/ClusterWarningCount.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterWarningCount.tsx
@@ -1,0 +1,35 @@
+import { FC } from "react";
+import { Cluster } from "types/cluster";
+import { Icon, Tooltip } from "@canonical/react-components";
+import { getClusterWarnings } from "util/clusterWarnings";
+
+interface Props {
+  cluster: Cluster;
+}
+
+export const ClusterWarningCount: FC<Props> = ({ cluster }: Props) => {
+  const warnings = getClusterWarnings(cluster);
+  const warningCount = warnings.length;
+
+  return warningCount == 0 ? (
+    0
+  ) : (
+    <Tooltip
+      message={warnings.map((warning, index) => (
+        <div key={index}>{warning}</div>
+      ))}
+      positionElementClassName="tooltip"
+      position="left"
+    >
+      <div className="u-pointer">
+        {warningCount}
+        {warningCount > 0 && (
+          <>
+            {" "}
+            <Icon name="warning" />
+          </>
+        )}
+      </div>
+    </Tooltip>
+  );
+};

--- a/ui/src/pages/clusters/metrics/ClusterWarningList.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterWarningList.tsx
@@ -1,0 +1,29 @@
+import { FC } from "react";
+import { Cluster } from "types/cluster";
+import { getClusterWarnings } from "util/clusterWarnings";
+
+interface Props {
+  cluster: Cluster;
+}
+
+export const ClusterWarningList: FC<Props> = ({ cluster }: Props) => {
+  const warnings = getClusterWarnings(cluster);
+
+  return (
+    <>
+      <h5>Warnings</h5>
+      {warnings.length > 0 ? (
+        <ul className="cluster-warning-list">
+          {warnings.map((warning, index) => (
+            <li key={index}>{warning}</li>
+          ))}
+        </ul>
+      ) : (
+        <>
+          <div>This cluster has no warnings.</div>
+          <div className="u-text--muted">You’re doing something right!</div>
+        </>
+      )}
+    </>
+  );
+};

--- a/ui/src/sass/_cluster_detail.scss
+++ b/ui/src/sass/_cluster_detail.scss
@@ -8,12 +8,12 @@
     flex-direction: column;
 
     .meter-row {
-      align-items: center;
+      align-items: flex-start;
       display: flex;
       gap: 1rem;
 
       .meter-row__title {
-        min-width: 5rem;
+        min-width: 8rem;
         text-align: right;
       }
 

--- a/ui/src/sass/styles.scss
+++ b/ui/src/sass/styles.scss
@@ -62,3 +62,7 @@ body {
 .p-notification__message {
   word-break: break-word;
 }
+
+.u-pointer {
+  cursor: pointer;
+}

--- a/ui/src/util/clusterWarnings.tsx
+++ b/ui/src/util/clusterWarnings.tsx
@@ -1,0 +1,50 @@
+import { Cluster } from "types/cluster";
+import { getMinutesSinceLastHeartbeat, pluralizeWord } from "util/helpers";
+
+const DISK_USAGE_PERCENTAGE_THRESHOLD = 90;
+const MEMORY_USAGE_PERCENTAGE_THRESHOLD = 90;
+
+export const getClusterWarnings = (cluster: Cluster): string[] => {
+  const result: string[] = [];
+
+  const diskUsagePercent =
+    (100 / cluster.disk_total_size) * cluster.disk_usage || 0;
+  if (diskUsagePercent > DISK_USAGE_PERCENTAGE_THRESHOLD) {
+    result.push(`Disk usage is at ${Math.ceil(diskUsagePercent)}%.`);
+  }
+
+  const memoryUsagePercent =
+    (100 / cluster.memory_total_amount) * cluster.memory_usage || 0;
+  if (memoryUsagePercent > MEMORY_USAGE_PERCENTAGE_THRESHOLD) {
+    result.push(`Memory usage is at ${Math.ceil(memoryUsagePercent)}%.`);
+  }
+
+  const nonOnlineMemberCount =
+    cluster.member_statuses
+      .filter((item) => item.status !== "Online")
+      .map((item) => item.count)
+      .reduce((a, b) => a + b, 0) || 0;
+  if (nonOnlineMemberCount > 0) {
+    result.push(
+      `${nonOnlineMemberCount} cluster ${pluralizeWord("member", nonOnlineMemberCount)} not online.`,
+    );
+  }
+
+  const errorInstanceCount =
+    cluster.instance_statuses.find((item) => item.status === "Error")?.count ||
+    0;
+  if (errorInstanceCount > 0) {
+    result.push(
+      `${errorInstanceCount} ${pluralizeWord("instance", errorInstanceCount)} in error state.`,
+    );
+  }
+
+  const lastHeartbeatMins = getMinutesSinceLastHeartbeat(cluster);
+  if (lastHeartbeatMins >= 5) {
+    result.push(
+      `Cluster has not sent a heartbeat in the last ${lastHeartbeatMins} minutes.`,
+    );
+  }
+
+  return result;
+};

--- a/ui/tests/helpers/remote-cluster-tokens.ts
+++ b/ui/tests/helpers/remote-cluster-tokens.ts
@@ -5,7 +5,7 @@ export const createRemoteClusterToken = async (
   clusterName: string,
 ) => {
   await page.goto("/ui");
-  await page.getByRole("button", { name: "Add New Cluster" }).click();
+  await page.getByRole("button", { name: "Enrol cluster" }).click();
   await page.getByPlaceholder("Enter Name").click();
   await page.getByPlaceholder("Enter Name").fill(clusterName);
   await page.getByRole("button", { name: "Create" }).click();


### PR DESCRIPTION
# Done
- make cluster list page text only
- collapse heartbeat and status column
- remove cpu usage from cluster list
- added warning concept based on offline members, error status instances and memory or disk
- pluralize instance / member on cluster detail page
- change memory/disk captions on cluster detail page to "Total memory" and "Total storage".

# Screenshots 

![image](https://github.com/user-attachments/assets/05e40dfc-4e9b-4f69-8a65-e5cea1594ff7)

![image](https://github.com/user-attachments/assets/684e8f37-14fe-4fcf-94e9-9775453a7a85)

![image](https://github.com/user-attachments/assets/fb6acded-f5de-4ee1-b18e-cb21ea7fd4fe)

![image](https://github.com/user-attachments/assets/9e5d6631-fbc2-4eb5-8519-b633e69796c0)

![image](https://github.com/user-attachments/assets/f0dafd21-41b5-4ce2-a683-6aca3dba2274)



