### PR TITLE
use storage pool usage per cluster instead of total storage usage

### DIFF
--- a/internal/app/cluster-connector/api/v1/remote_cluster.go
+++ b/internal/app/cluster-connector/api/v1/remote_cluster.go
@@ -127,9 +127,10 @@ func remoteClustersPost(rc types.RouteConfig) types.EndpointHandler {
 
 			// create relevant remote cluster details
 			_, err = store.CreateRemoteClusterDetail(ctx, tx, store.RemoteClusterDetail{
-				RemoteClusterID:  newRemoteCluster.ID,
-				MemberStatuses:   json.RawMessage("[]"),
-				InstanceStatuses: json.RawMessage("[]"),
+				RemoteClusterID:   newRemoteCluster.ID,
+				MemberStatuses:    json.RawMessage("[]"),
+				InstanceStatuses:  json.RawMessage("[]"),
+				StoragePoolUsages: json.RawMessage("[]"),
 			})
 
 			if err != nil {

--- a/internal/app/management-api/api/v1/remote_cluster.go
+++ b/internal/app/management-api/api/v1/remote_cluster.go
@@ -190,16 +190,22 @@ func toRemoteClustersAPI(dbEntries []store.RemoteClusterWithDetail) ([]models.Re
 	// generate lookup for remoteCluster details
 	var remoteClusters []models.RemoteCluster
 	for _, e := range dbEntries {
-		var ms []models.StatusDistribution
-		err := json.Unmarshal(e.MemberStatuses, &ms)
+		var memberStatuses []models.StatusDistribution
+		err := json.Unmarshal(e.MemberStatuses, &memberStatuses)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal member statuses: %w", err)
 		}
 
-		var is []models.StatusDistribution
-		err = json.Unmarshal(e.InstanceStatuses, &is)
+		var instanceStatuses []models.StatusDistribution
+		err = json.Unmarshal(e.InstanceStatuses, &instanceStatuses)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal instance statuses: %w", err)
+		}
+
+		var storagePoolUsages []models.StoragePoolUsage
+		err = json.Unmarshal(e.StoragePoolUsages, &storagePoolUsages)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal storage pool usages: %w", err)
 		}
 
 		remoteClusters = append(remoteClusters, models.RemoteCluster{
@@ -215,12 +221,11 @@ func toRemoteClustersAPI(dbEntries []store.RemoteClusterWithDetail) ([]models.Re
 			CPULoad15:          e.CPULoad15,
 			MemoryTotalAmount:  e.MemoryTotalAmount,
 			MemoryUsage:        e.MemoryUsage,
-			DiskTotalSize:      e.DiskTotalSize,
-			DiskUsage:          e.DiskUsage,
 			MemberCount:        e.MemberCount,
-			MemberStatuses:     ms,
+			MemberStatuses:     memberStatuses,
 			InstanceCount:      e.InstanceCount,
-			InstanceStatuses:   is,
+			InstanceStatuses:   instanceStatuses,
+			StoragePoolUsages:  storagePoolUsages,
 			UIURL:              e.UIURL,
 			JoinedAt:           e.ClusterJoinedAt,
 			CreatedAt:          e.ClusterCreatedAt,

--- a/internal/pkg/api/models/v1/remote_cluster.go
+++ b/internal/pkg/api/models/v1/remote_cluster.go
@@ -23,6 +23,14 @@ type ServerMetrics struct {
 	Service string `json:"service"`
 }
 
+// StoragePoolUsage represents the storage usage distribution.
+type StoragePoolUsage struct {
+	Name   string `json:"name"`
+	Member string `json:"member"`
+	Total  uint64 `json:"total"`
+	Usage  uint64 `json:"usage"`
+}
+
 // RemoteCluster is a standalone or clustered LXD cluster.
 type RemoteCluster struct {
 	Name               string               `json:"name"`
@@ -37,8 +45,7 @@ type RemoteCluster struct {
 	CPULoad15          string               `json:"cpu_load_15"`
 	MemoryTotalAmount  int64                `json:"memory_total_amount"`
 	MemoryUsage        int64                `json:"memory_usage"`
-	DiskTotalSize      int64                `json:"disk_total_size"`
-	DiskUsage          int64                `json:"disk_usage"`
+	StoragePoolUsages  []StoragePoolUsage   `json:"storage_pool_usages"`
 	MemberCount        int64                `json:"member_count"`
 	MemberStatuses     []StatusDistribution `json:"member_statuses"`
 	InstanceCount      int64                `json:"instance_count"`
@@ -72,8 +79,7 @@ type RemoteClusterStatusPost struct {
 	CPULoad15         string               `json:"cpu_load_15"`
 	MemoryTotalAmount int64                `json:"memory_total_amount"`
 	MemoryUsage       int64                `json:"memory_usage"`
-	DiskTotalSize     int64                `json:"disk_total_size"`
-	DiskUsage         int64                `json:"disk_usage"`
+	StoragePoolUsages []StoragePoolUsage   `json:"storage_pool_usages"`
 	MemberStatuses    []StatusDistribution `json:"member_statuses"`
 	InstanceStatuses  []StatusDistribution `json:"instance_statuses"`
 	ServerMetrics     []ServerMetrics      `json:"server_metrics"`

--- a/internal/pkg/database/schema/migrations/00001_db.sql
+++ b/internal/pkg/database/schema/migrations/00001_db.sql
@@ -48,12 +48,11 @@ CREATE TABLE IF NOT EXISTS remote_cluster_details (
     cpu_load_15 TEXT NOT NULL DEFAULT 0,
     memory_total_amount BIGINT NOT NULL DEFAULT 0,
     memory_usage BIGINT NOT NULL DEFAULT 0,
-    disk_total_size BIGINT NOT NULL DEFAULT 0,
-    disk_usage BIGINT NOT NULL DEFAULT 0,
     instance_count INTEGER NOT NULL DEFAULT 0,
     instance_statuses JSONB NOT NULL DEFAULT '[]'::JSONB,
     member_count INTEGER NOT NULL DEFAULT 0,
     member_statuses JSONB NOT NULL DEFAULT '[]'::JSONB,
+    storage_pool_usages JSONB NOT NULL DEFAULT '[]'::JSONB,
     ui_url TEXT NOT NULL DEFAULT '',
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP

--- a/internal/pkg/database/seed/seed.go
+++ b/internal/pkg/database/seed/seed.go
@@ -231,6 +231,45 @@ func generateRandomStatuses(status1, status2, status3, status4 string, maxCount 
 	return result, nil
 }
 
+func generateStoragePoolUsages(totalMembers int64) []byte {
+	poolCount := rand.IntN(3) + 1 // 1 to 3 pools
+
+	poolUsages := []map[string]any{}
+	for i := 0; i < poolCount; i++ {
+		isLocal := rand.Float64() < 0.5
+
+		if isLocal {
+			for j := 0; int64(j) < totalMembers; j++ {
+				totalDisk, diskUsage := generateDiskUsage()
+				poolUsages = append(poolUsages, map[string]any{
+					"name":   fmt.Sprintf("pool-%d", i+1),
+					"member": fmt.Sprintf("member-%d", j+1),
+					"total":  totalDisk,
+					"usage":  diskUsage,
+				})
+			}
+		} else {
+			totalDisk, diskUsage := generateDiskUsage()
+			poolUsages = append(poolUsages, map[string]any{
+				"name":  fmt.Sprintf("pool-%d", i+1),
+				"total": totalDisk,
+				"usage": diskUsage,
+			})
+		}
+	}
+
+	result, _ := json.Marshal(poolUsages)
+	return result
+}
+
+func generateDiskUsage() (int64, int64) {
+	totalDisk := (rand.Int64N(200) + 1) * 100 * 1024 * 1024 * 1024 // Random disk size in multiples of 1000
+	halfDisk := totalDisk / 2
+	diskUsage := rand.Int64N(halfDisk + 1) // max half the disk is used
+
+	return totalDisk, diskUsage
+}
+
 // GenerateRemoteClusterDetails generates a slice of RemoteClusterDetail with the specified number of entries.
 func generateRemoteClusterDetails(count int) ([]store.RemoteClusterDetail, error) {
 	clusters := make([]store.RemoteClusterDetail, count)
@@ -238,10 +277,7 @@ func generateRemoteClusterDetails(count int) ([]store.RemoteClusterDetail, error
 	for i := 0; i < count; i++ {
 		totalMemory := (rand.Int64N(16) + 1) * 32 * 1024 * 1024 * 1024 // Random memory in multiples of 1024
 		quarterMemory := totalMemory / 4
-		memoryUsage := quarterMemory + rand.Int64N(quarterMemory+1)    // max half and minimum a quarter of memory is used
-		totalDisk := (rand.Int64N(200) + 1) * 100 * 1024 * 1024 * 1024 // Random disk size in multiples of 1000
-		halfDisk := totalDisk / 2
-		diskUsage := rand.Int64N(halfDisk + 1) // max half the disk is used
+		memoryUsage := quarterMemory + rand.Int64N(quarterMemory+1) // max half and minimum a quarter of memory is used
 		totalInstances := rand.Int64N(50) + 6
 		totalMembers := rand.Int64N(20) + 6
 
@@ -263,12 +299,11 @@ func generateRemoteClusterDetails(count int) ([]store.RemoteClusterDetail, error
 			CPULoad15:         fmt.Sprintf("%.1f", rand.Float64()),
 			MemoryTotalAmount: totalMemory,
 			MemoryUsage:       memoryUsage,
-			DiskTotalSize:     totalDisk,
-			DiskUsage:         diskUsage,
 			InstanceCount:     totalInstances,
 			InstanceStatuses:  instanceStatuses,
 			MemberCount:       totalMembers,
 			MemberStatuses:    memberStatuses,
+			StoragePoolUsages: generateStoragePoolUsages(totalMembers),
 			CreatedAt:         time.Now(),
 			UpdatedAt:         time.Now(),
 		}
@@ -292,9 +327,9 @@ func seedRemoteClusterDetails(ctx context.Context, db *database.DB) error {
 		for idx, detail := range remoteClusterDetails {
 			q := `
 				INSERT INTO remote_cluster_details 
-					(remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, disk_total_size, disk_usage, instance_count, instance_statuses, member_count, member_statuses)
+					(remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, instance_count, instance_statuses, member_count, member_statuses, storage_pool_usages)
 				VALUES 
-					($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+					($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 				ON CONFLICT (remote_cluster_id)
 				DO UPDATE SET
 					remote_cluster_id = $1,
@@ -304,14 +339,13 @@ func seedRemoteClusterDetails(ctx context.Context, db *database.DB) error {
 					cpu_load_15 = $5,
 					memory_total_amount = $6,
 					memory_usage = $7,
-					disk_total_size = $8,
-					disk_usage = $9,
-					instance_count = $10,
-					instance_statuses = $11,
-					member_count = $12,
-					member_statuses = $13
+					instance_count = $8,
+					instance_statuses = $9,
+					member_count = $10,
+					member_statuses = $11,
+				    storage_pool_usages = $12
 				RETURNING 
-					id, remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, disk_total_size, disk_usage, instance_count, instance_statuses, member_count, member_statuses, created_at, updated_at;
+					id, remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, instance_count, instance_statuses, member_count, member_statuses, storage_pool_usages, created_at, updated_at;
 			`
 
 			detail.RemoteClusterID = clusters[idx].ID
@@ -324,12 +358,11 @@ func seedRemoteClusterDetails(ctx context.Context, db *database.DB) error {
 				detail.CPULoad15,
 				detail.MemoryTotalAmount,
 				detail.MemoryUsage,
-				detail.DiskTotalSize,
-				detail.DiskUsage,
 				detail.InstanceCount,
 				detail.InstanceStatuses,
 				detail.MemberCount,
 				detail.MemberStatuses,
+				detail.StoragePoolUsages,
 			).Scan(
 				&result.ID,
 				&result.RemoteClusterID,
@@ -339,12 +372,11 @@ func seedRemoteClusterDetails(ctx context.Context, db *database.DB) error {
 				&result.CPULoad15,
 				&result.MemoryTotalAmount,
 				&result.MemoryUsage,
-				&result.DiskTotalSize,
-				&result.DiskUsage,
 				&result.InstanceCount,
 				&result.InstanceStatuses,
 				&result.MemberCount,
 				&result.MemberStatuses,
+				&result.StoragePoolUsages,
 				&result.CreatedAt,
 				&result.UpdatedAt,
 			)

--- a/internal/pkg/database/store/remote_cluster_detail.go
+++ b/internal/pkg/database/store/remote_cluster_detail.go
@@ -17,23 +17,22 @@ import (
 
 // RemoteClusterDetail represents detailed information about a remote LXD cluster.
 type RemoteClusterDetail struct {
-	ID                int             `db:"id"`                  // Primary key
-	RemoteClusterID   int             `db:"remote_cluster_id"`   // Foreign key to remote_clusters
-	CPUTotalCount     int64           `db:"cpu_total_count"`     // Total CPU count
-	CPULoad1          string          `db:"cpu_load_1"`          // CPU load (1 minute average)
-	CPULoad5          string          `db:"cpu_load_5"`          // CPU load (5 minute average)
-	CPULoad15         string          `db:"cpu_load_15"`         // CPU load (15 minute average)
-	MemoryTotalAmount int64           `db:"memory_total_amount"` // Total memory in bytes
-	MemoryUsage       int64           `db:"memory_usage"`        // Memory usage in bytes
-	DiskTotalSize     int64           `db:"disk_total_size"`     // Total disk size in bytes
-	DiskUsage         int64           `db:"disk_usage"`          // Disk usage in bytes
-	InstanceCount     int64           `db:"instance_count"`      // Number of instances
-	InstanceStatuses  json.RawMessage `db:"instance_statuses"`   // JSON array of instance statuses
-	MemberCount       int64           `db:"member_count"`        // Number of members
-	MemberStatuses    json.RawMessage `db:"member_statuses"`     // JSON array of member statuses
-	UIURL             string          `db:"ui_url"`              // UI URL
-	CreatedAt         time.Time       `db:"created_at"`          // Creation timestamp
-	UpdatedAt         time.Time       `db:"updated_at"`          // Update timestamp
+	ID                int             `db:"id"`                    // Primary key
+	RemoteClusterID   int             `db:"remote_cluster_id"`     // Foreign key to remote_clusters
+	CPUTotalCount     int64           `db:"cpu_total_count"`       // Total CPU count
+	CPULoad1          string          `db:"cpu_load_1"`            // CPU load (1 minute average)
+	CPULoad5          string          `db:"cpu_load_5"`            // CPU load (5 minute average)
+	CPULoad15         string          `db:"cpu_load_15"`           // CPU load (15 minute average)
+	MemoryTotalAmount int64           `db:"memory_total_amount"`   // Total memory in bytes
+	MemoryUsage       int64           `db:"memory_usage"`          // Memory usage in bytes
+	InstanceCount     int64           `db:"instance_count"`        // Number of instances
+	InstanceStatuses  json.RawMessage `db:"instance_statuses"`     // JSON array of instance statuses
+	MemberCount       int64           `db:"member_count"`          // Number of members
+	MemberStatuses    json.RawMessage `db:"member_statuses"`       // JSON array of member statuses
+	StoragePoolUsages json.RawMessage `json:"storage_pool_usages"` // JSON array of storage pool usages
+	UIURL             string          `db:"ui_url"`                // UI URL
+	CreatedAt         time.Time       `db:"created_at"`            // Creation timestamp
+	UpdatedAt         time.Time       `db:"updated_at"`            // Update timestamp
 }
 
 // Put updates the RemoteClusterDetail with the provided payload.
@@ -42,12 +41,11 @@ func (r *RemoteClusterDetail) Put(payload models.RemoteClusterStatusPost) {
 	r.CPULoad5 = payload.CPULoad5
 	r.CPULoad15 = payload.CPULoad15
 	r.CPUTotalCount = payload.CPUTotalCount
-	r.DiskTotalSize = payload.DiskTotalSize
-	r.DiskUsage = payload.DiskUsage
 	r.InstanceCount, r.InstanceStatuses = parseStatusDistribution(payload.InstanceStatuses)
 	r.MemberCount, r.MemberStatuses = parseStatusDistribution(payload.MemberStatuses)
 	r.MemoryTotalAmount = payload.MemoryTotalAmount
 	r.MemoryUsage = payload.MemoryUsage
+	r.StoragePoolUsages = parsePoolUsage(payload.StoragePoolUsages)
 	r.UIURL = payload.UIURL
 	r.UpdatedAt = time.Now()
 }
@@ -68,12 +66,11 @@ type RemoteClusterWithDetail struct {
 	CPULoad15          string          `db:"cpu_load_15"`
 	MemoryTotalAmount  int64           `db:"memory_total_amount"`
 	MemoryUsage        int64           `db:"memory_usage"`
-	DiskTotalSize      int64           `db:"disk_total_size"`
-	DiskUsage          int64           `db:"disk_usage"`
 	InstanceCount      int64           `db:"instance_count"`
 	InstanceStatuses   json.RawMessage `db:"instance_statuses"`
 	MemberCount        int64           `db:"member_count"`
 	MemberStatuses     json.RawMessage `db:"member_statuses"`
+	StoragePoolUsages  json.RawMessage `json:"storage_pool_usages"`
 	UIURL              string          `db:"ui_url"`
 	ClusterJoinedAt    time.Time       `db:"joined_at"`
 	ClusterUpdatedAt   time.Time       `db:"updated_at"`
@@ -120,9 +117,9 @@ func GetRemoteClusterDetail(ctx context.Context, tx *sqlx.Tx, remoteClusterID in
 	q := `
         SELECT 
 			id, remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, 
-			cpu_load_15, memory_total_amount, memory_usage, disk_total_size, 
-			disk_usage, instance_count, instance_statuses, member_count, 
-			member_statuses, ui_url, created_at, updated_at
+			cpu_load_15, memory_total_amount, memory_usage, 
+			instance_count, instance_statuses, member_count, 
+			member_statuses, storage_pool_usages, ui_url, created_at, updated_at
         FROM remote_cluster_details
 		WHERE remote_cluster_id = $1;
     `
@@ -137,12 +134,11 @@ func GetRemoteClusterDetail(ctx context.Context, tx *sqlx.Tx, remoteClusterID in
 		&result.CPULoad15,
 		&result.MemoryTotalAmount,
 		&result.MemoryUsage,
-		&result.DiskTotalSize,
-		&result.DiskUsage,
 		&result.InstanceCount,
 		&result.InstanceStatuses,
 		&result.MemberCount,
 		&result.MemberStatuses,
+		&result.StoragePoolUsages,
 		&result.UIURL,
 		&result.CreatedAt,
 		&result.UpdatedAt,
@@ -172,11 +168,11 @@ func CreateRemoteClusterDetail(ctx context.Context, tx *sqlx.Tx, data RemoteClus
 
 	q := `
         INSERT INTO remote_cluster_details 
-			(remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, disk_total_size, disk_usage, instance_count, instance_statuses, member_count, member_statuses, ui_url)
+			(remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, instance_count, instance_statuses, member_count, member_statuses, storage_pool_usages, ui_url)
         VALUES 
-			($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+			($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
         RETURNING 
-			id, remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, disk_total_size, disk_usage, instance_count, instance_statuses, member_count, member_statuses, ui_url, created_at, updated_at;
+			id, remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, instance_count, instance_statuses, member_count, member_statuses, storage_pool_usages, ui_url, created_at, updated_at;
     `
 
 	var result RemoteClusterDetail
@@ -188,12 +184,11 @@ func CreateRemoteClusterDetail(ctx context.Context, tx *sqlx.Tx, data RemoteClus
 		data.CPULoad15,
 		data.MemoryTotalAmount,
 		data.MemoryUsage,
-		data.DiskTotalSize,
-		data.DiskUsage,
 		data.InstanceCount,
 		data.InstanceStatuses,
 		data.MemberCount,
 		data.MemberStatuses,
+		data.StoragePoolUsages,
 		data.UIURL,
 	).Scan(
 		&result.ID,
@@ -204,12 +199,11 @@ func CreateRemoteClusterDetail(ctx context.Context, tx *sqlx.Tx, data RemoteClus
 		&result.CPULoad15,
 		&result.MemoryTotalAmount,
 		&result.MemoryUsage,
-		&result.DiskTotalSize,
-		&result.DiskUsage,
 		&result.InstanceCount,
 		&result.InstanceStatuses,
 		&result.MemberCount,
 		&result.MemberStatuses,
+		&result.StoragePoolUsages,
 		&result.UIURL,
 		&result.CreatedAt,
 		&result.UpdatedAt,
@@ -231,8 +225,8 @@ func UpdateRemoteClusterDetail(ctx context.Context, tx *sqlx.Tx, remoteClusterID
 
 	q := `
         UPDATE remote_cluster_details
-        SET cpu_total_count = $1, cpu_load_1 = $2, cpu_load_5 = $3, cpu_load_15 = $4, memory_total_amount = $5, memory_usage = $6, disk_total_size = $7, disk_usage = $8, instance_count = $9, instance_statuses = $10, member_count = $11, member_statuses = $12, ui_url = $13
-        WHERE id = $14;
+        SET cpu_total_count = $1, cpu_load_1 = $2, cpu_load_5 = $3, cpu_load_15 = $4, memory_total_amount = $5, memory_usage = $6, instance_count = $7, instance_statuses = $8, member_count = $9, member_statuses = $10, storage_pool_usages = $11, ui_url = $12, updated_at = NOW()
+        WHERE id = $13;
     `
 
 	result, err := tx.ExecContext(ctx, q,
@@ -242,12 +236,11 @@ func UpdateRemoteClusterDetail(ctx context.Context, tx *sqlx.Tx, remoteClusterID
 		data.CPULoad15,
 		data.MemoryTotalAmount,
 		data.MemoryUsage,
-		data.DiskTotalSize,
-		data.DiskUsage,
 		data.InstanceCount,
 		data.InstanceStatuses,
 		data.MemberCount,
 		data.MemberStatuses,
+		data.StoragePoolUsages,
 		data.UIURL,
 		id,
 	)
@@ -282,12 +275,11 @@ var baseDetailQuery = `
 		remote_cluster_details.cpu_load_15,
 		remote_cluster_details.memory_total_amount,
 		remote_cluster_details.memory_usage,
-		remote_cluster_details.disk_total_size,
-		remote_cluster_details.disk_usage,
 		remote_cluster_details.instance_count,
 		remote_cluster_details.instance_statuses,
 		remote_cluster_details.member_count,
 		remote_cluster_details.member_statuses,
+		remote_cluster_details.storage_pool_usages,
 		remote_cluster_details.ui_url,
 		remote_cluster_details.updated_at,
 		COALESCE(
@@ -324,12 +316,11 @@ func getRemoteClusterWithDetails(ctx context.Context, tx *sqlx.Tx, sql string, a
 			&c.CPULoad15,
 			&c.MemoryTotalAmount,
 			&c.MemoryUsage,
-			&c.DiskTotalSize,
-			&c.DiskUsage,
 			&c.InstanceCount,
 			&c.InstanceStatuses,
 			&c.MemberCount,
 			&c.MemberStatuses,
+			&c.StoragePoolUsages,
 			&c.UIURL,
 			&c.ClusterUpdatedAt,
 			&c.DiskThreshold,
@@ -409,4 +400,17 @@ func parseStatusDistribution(statuses []models.StatusDistribution) (int64, json.
 	}
 
 	return total, parsedStatuses
+}
+
+func parsePoolUsage(usages []models.StoragePoolUsage) json.RawMessage {
+	if len(usages) == 0 {
+		return json.RawMessage("[]")
+	}
+
+	parsedUsages, err := json.Marshal(usages)
+	if err != nil {
+		return json.RawMessage("[]")
+	}
+
+	return parsedUsages
 }

--- a/test/e2e/remote_cluster_success.go
+++ b/test/e2e/remote_cluster_success.go
@@ -126,11 +126,6 @@ func testRemoteClusterSuccess(env *helpers.Environment) (testName string, testFu
 				helpers.LogTestOutcome(t, condition, err)
 			}
 
-			if remoteCluster.DiskTotalSize != 1024 {
-				err = fmt.Errorf("invalid disk total size")
-				helpers.LogTestOutcome(t, condition, err)
-			}
-
 			if !reflect.DeepEqual(remoteCluster.InstanceStatuses, []models.StatusDistribution{
 				{Status: "running", Count: 1},
 				{Status: "stopped", Count: 2},
@@ -142,6 +137,14 @@ func testRemoteClusterSuccess(env *helpers.Environment) (testName string, testFu
 			if !reflect.DeepEqual(remoteCluster.MemberStatuses, []models.StatusDistribution{
 				{Status: "active", Count: 1},
 				{Status: "inactive", Count: 2},
+			}) {
+				err = fmt.Errorf("invalid member statuses")
+				helpers.LogTestOutcome(t, condition, err)
+			}
+
+			if !reflect.DeepEqual(remoteCluster.StoragePoolUsages, []models.StoragePoolUsage{
+				{Name: "default", Total: 1024, Usage: 512},
+				{Name: "data", Total: 2048, Usage: 1024},
 			}) {
 				err = fmt.Errorf("invalid member statuses")
 				helpers.LogTestOutcome(t, condition, err)

--- a/test/helpers/metrics_agent.sh
+++ b/test/helpers/metrics_agent.sh
@@ -156,8 +156,6 @@ send_status_updates() {
     "cpu_load_15": "0.0",
     "memory_total_amount": 0,
     "memory_usage": 0,
-    "disk_total_size": 0,
-    "disk_usage": 0,
     "member_statuses": [],
     "instance_statuses": [],
     "metrics": $(jq -Rs . <<< "$metrics")
@@ -200,8 +198,6 @@ while true; do
     "cpu_load_15": "0.0",
     "memory_total_amount": 0,
     "memory_usage": 0,
-    "disk_total_size": 0,
-    "disk_usage": 0,
     "member_statuses": [],
     "instance_statuses": [],
     "metrics": $(jq -Rs . <<< "$metrics")

--- a/test/helpers/remote_clusters.go
+++ b/test/helpers/remote_clusters.go
@@ -155,8 +155,6 @@ func CreateStatusPostData() models.RemoteClusterStatusPost {
 		CPULoad15:         "0.3",
 		MemoryTotalAmount: 1024,
 		MemoryUsage:       512,
-		DiskTotalSize:     1024,
-		DiskUsage:         512,
 		InstanceStatuses: []models.StatusDistribution{
 			{Status: "running", Count: 1},
 			{Status: "stopped", Count: 2},
@@ -164,6 +162,10 @@ func CreateStatusPostData() models.RemoteClusterStatusPost {
 		MemberStatuses: []models.StatusDistribution{
 			{Status: "active", Count: 1},
 			{Status: "inactive", Count: 2},
+		},
+		StoragePoolUsages: []models.StoragePoolUsage{
+			{Name: "default", Total: 1024, Usage: 512},
+			{Name: "data", Total: 2048, Usage: 1024},
 		},
 	}
 }

--- a/ui/src/pages/clusters/ClusterList.tsx
+++ b/ui/src/pages/clusters/ClusterList.tsx
@@ -6,7 +6,13 @@ import TabLinks from "components/TabLinks";
 import ClusterListTokens from "./ClusterListTokens";
 import ClusterListActive from "./ClusterListActive";
 import NotificationRow from "components/NotificationRow";
-import ClusterSearchFilter from "pages/clusters/ClusterSearchFilter";
+import ClusterSearchFilter, {
+  INSTANCE_STATUS,
+  MEMORY_USAGE,
+  NODE_STATUS,
+  POOL_USAGE,
+  QUERY,
+} from "pages/clusters/ClusterSearchFilter";
 import CustomLayout from "components/CustomLayout";
 import PageHeader from "components/PageHeader";
 import { useQuery } from "@tanstack/react-query";
@@ -91,16 +97,16 @@ const ClusterList: FC = () => {
   }, [clusters, activeTab]);
 
   const filters: ClusterFilters = {
-    queries: searchParams.getAll("query"),
+    queries: searchParams.getAll(QUERY),
     instanceStatuses: searchParams.getAll(
-      "instance-status",
+      INSTANCE_STATUS,
     ) as ClusterInstanceStatus[],
-    nodeStatuses: searchParams.getAll("node-status") as ClusterNodeStatus[],
+    nodeStatuses: searchParams.getAll(NODE_STATUS) as ClusterNodeStatus[],
     memoryUsage: toNumericUsagePercentiles(
-      searchParams.getAll("memory-usage"),
+      searchParams.getAll(MEMORY_USAGE),
     ) as ClusterPercentiles[],
-    diskUsage: toNumericUsagePercentiles(
-      searchParams.getAll("disk-usage"),
+    storagePoolUsage: toNumericUsagePercentiles(
+      searchParams.getAll(POOL_USAGE),
     ) as ClusterPercentiles[],
   };
 
@@ -140,14 +146,17 @@ const ClusterList: FC = () => {
       return false;
     }
 
+    //Search by Storage pool usage
+    const maxStorageFilter = Math.max(...filters.storagePoolUsage, 0);
+    const maxStorageUsage = Math.max(
+      ...item.storage_pool_usages.map(
+        (usage) => ((100 / usage.total) * usage.usage) / 100 || 0,
+      ),
+      0,
+    );
     if (
-      //Search by Cluster disk usage
-      filters.diskUsage.length > 0 &&
-      !hasAllUsagePercentileBands(
-        filters.diskUsage,
-        item.disk_usage,
-        item.disk_total_size,
-      )
+      filters.storagePoolUsage.length > 0 &&
+      maxStorageFilter > maxStorageUsage
     ) {
       return false;
     }

--- a/ui/src/pages/clusters/ClusterSearchFilter.tsx
+++ b/ui/src/pages/clusters/ClusterSearchFilter.tsx
@@ -18,7 +18,7 @@ export const NAME = "name";
 export const INSTANCE_STATUS = "instance-status";
 export const NODE_STATUS = "node-status";
 export const MEMORY_USAGE = "memory-usage";
-export const DISK_USAGE = "disk-usage";
+export const POOL_USAGE = "pool-usage";
 
 const QUERY_PARAMS = [
   QUERY,
@@ -26,7 +26,7 @@ const QUERY_PARAMS = [
   INSTANCE_STATUS,
   NODE_STATUS,
   MEMORY_USAGE,
-  DISK_USAGE,
+  POOL_USAGE,
 ];
 
 const ClusterSearchFilter: FC = () => {
@@ -49,16 +49,16 @@ const ClusterSearchFilter: FC = () => {
     },
     {
       id: 3,
-      heading: "Memory Usage",
+      heading: "Memory usage",
       chips: usagePercentiles.map((percentile) => {
         return { lead: MEMORY_USAGE, value: percentile };
       }),
     },
     {
       id: 4,
-      heading: "Disk Usage",
+      heading: "Storage pool usage",
       chips: usagePercentiles.map((percentile) => {
-        return { lead: DISK_USAGE, value: percentile };
+        return { lead: POOL_USAGE, value: percentile };
       }),
     },
   ];

--- a/ui/src/pages/clusters/metrics/ClusterDetailMetrics.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterDetailMetrics.tsx
@@ -2,6 +2,7 @@ import type { Cluster } from "types/cluster";
 import { ClusterMemory } from "./ClusterMemory";
 import { ClusterDisk } from "./ClusterDisk";
 import type { FC } from "react";
+import { ClusterDiskInfo } from "pages/clusters/metrics/ClusterDiskInfo";
 
 interface Props {
   cluster: Cluster;
@@ -21,7 +22,7 @@ const ClusterDetailMetrics: FC<Props> = ({ cluster }: Props) => {
       </div>
       <div className="meter-row">
         <span className="meter-row__title u-no-margin p-heading--5 u-no-padding">
-          Total storage
+          Total storage <ClusterDiskInfo cluster={cluster} />
         </span>
         <ClusterDisk
           cluster={cluster}

--- a/ui/src/pages/clusters/metrics/ClusterDisk.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterDisk.tsx
@@ -12,11 +12,20 @@ export const ClusterDisk: FC<Props> = ({
   cluster,
   containerClassname,
 }: Props) => {
+  const totalUsage = cluster.storage_pool_usages.reduce(
+    (acc, pool) => acc + pool.usage,
+    0,
+  );
+  const totalSize = cluster.storage_pool_usages.reduce(
+    (acc, pool) => acc + pool.total,
+    0,
+  );
+
   return (
     <Meter
       containerClassname={containerClassname || ""}
-      percentage={(100 / cluster.disk_total_size) * cluster.disk_usage || 0}
-      text={`${humanFileSize(cluster.disk_usage)} of ${humanFileSize(cluster.disk_total_size)}`}
+      percentage={(100 / totalSize) * totalUsage || 0}
+      text={`${humanFileSize(totalUsage)} of ${humanFileSize(totalSize)}`}
       type="disk"
     />
   );

--- a/ui/src/pages/clusters/metrics/ClusterDiskInfo.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterDiskInfo.tsx
@@ -1,0 +1,26 @@
+import type { FC } from "react";
+import type { Cluster } from "types/cluster";
+import { Icon, usePortal } from "@canonical/react-components";
+import { Link } from "react-router-dom";
+import { ClusterDiskModal } from "pages/clusters/metrics/ClusterDiskModal";
+
+interface Props {
+  cluster: Cluster;
+}
+
+export const ClusterDiskInfo: FC<Props> = ({ cluster }: Props) => {
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+
+  return (
+    <>
+      {isOpen && (
+        <Portal>
+          <ClusterDiskModal cluster={cluster} onClose={closePortal} />
+        </Portal>
+      )}
+      <Link onClick={openPortal} to="#">
+        <Icon name="information" />
+      </Link>
+    </>
+  );
+};

--- a/ui/src/pages/clusters/metrics/ClusterDiskModal.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterDiskModal.tsx
@@ -1,0 +1,98 @@
+import type { FC } from "react";
+import type { Cluster } from "types/cluster";
+import { humanFileSize } from "util/helpers";
+import { Icon, MainTable, Modal } from "@canonical/react-components";
+
+interface Props {
+  cluster: Cluster;
+  onClose: () => void;
+}
+
+export const ClusterDiskModal: FC<Props> = ({ cluster, onClose }: Props) => {
+  const headers = [
+    {
+      content: "Storage Pool",
+      sortKey: "name",
+    },
+    {
+      content: "Location",
+      sortKey: "member",
+    },
+    {
+      content: "Percent Used",
+      sortKey: "percent_used",
+    },
+    {
+      content: "Total Used",
+      sortKey: "total_used",
+    },
+    {
+      content: "Total Size",
+      sortKey: "total_size",
+    },
+  ];
+
+  const poolDetails = cluster.storage_pool_usages.map((pool) => {
+    const poolPercent = Math.ceil((100 / pool.total) * pool.usage || 0);
+    const isWarning = poolPercent >= cluster.disk_threshold;
+
+    return {
+      key: pool.name + pool.member,
+      columns: [
+        {
+          content: (
+            <>
+              {pool.name}
+              {isWarning ? (
+                <>
+                  {" "}
+                  <Icon
+                    name="warning"
+                    title="High disk usage. Above disk threshold for this cluster"
+                  />
+                </>
+              ) : null}
+            </>
+          ),
+          role: "rowheader",
+        },
+        {
+          content: pool.member || "cluster wide",
+          role: "cell",
+          sortKey: pool.name,
+        },
+        {
+          content: <>{poolPercent}%</>,
+          role: "cell",
+        },
+        {
+          content: humanFileSize(pool.usage),
+          role: "cell",
+        },
+        {
+          content: humanFileSize(pool.total),
+          role: "cell",
+        },
+      ],
+      sortData: {
+        name: pool.name,
+        member: pool.member ?? "cluster wide",
+        percent_used: poolPercent,
+        total_used: pool.usage,
+        total_size: pool.total,
+      },
+    };
+  });
+
+  return (
+    <Modal close={onClose} title="Storage pool details">
+      <MainTable
+        headers={headers}
+        rows={poolDetails}
+        sortable
+        defaultSort="name"
+        defaultSortDirection="ascending"
+      />
+    </Modal>
+  );
+};

--- a/ui/src/pages/clusters/metrics/ClusterWarningList.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterWarningList.tsx
@@ -37,8 +37,8 @@ export const ClusterWarningList: FC<Props> = ({ cluster }: Props) => {
       {warnings.length > 0 ? (
         warnings.map((warning, index) => {
           const isMemoryUsage = warning.startsWith("Memory usage");
-          const isDiskUsage = warning.startsWith("Disk usage");
-          const canConfigure = isMemoryUsage || isDiskUsage;
+          const isPoolUsage = warning.startsWith("Storage pool");
+          const canConfigure = isMemoryUsage || isPoolUsage;
 
           const actions = [];
           if (canConfigure) {

--- a/ui/src/sass/_cluster_detail.scss
+++ b/ui/src/sass/_cluster_detail.scss
@@ -13,8 +13,7 @@
       gap: 1rem;
 
       .meter-row__title {
-        min-width: 8rem;
-        text-align: right;
+        min-width: 7.5rem;
       }
 
       .meter-row__metrics {

--- a/ui/src/types/cluster.d.ts
+++ b/ui/src/types/cluster.d.ts
@@ -3,6 +3,13 @@ export interface StatusDistribution {
   count: number;
 }
 
+export interface StoragePoolUsage {
+  name: string;
+  member?: string;
+  total: number;
+  usage: number;
+}
+
 export interface Cluster {
   name: string;
   description: string;
@@ -13,8 +20,6 @@ export interface Cluster {
   cpu_load_5: string;
   cpu_load_15: string;
   created_at: string;
-  disk_total_size: number;
-  disk_usage: number;
   instance_count: number;
   instance_statuses: StatusDistribution[];
   joined_at: string;
@@ -23,6 +28,7 @@ export interface Cluster {
   member_statuses: StatusDistribution[];
   memory_total_amount: number;
   memory_usage: number;
+  storage_pool_usages: StoragePoolUsage[];
   cluster_certificate: string;
   status: string;
   ui_url: string;

--- a/ui/src/util/clusterFilter.tsx
+++ b/ui/src/util/clusterFilter.tsx
@@ -10,7 +10,7 @@ export interface ClusterFilters {
   instanceStatuses: ClusterInstanceStatus[];
   nodeStatuses: ClusterNodeStatus[];
   memoryUsage: number[];
-  diskUsage: number[];
+  storagePoolUsage: number[];
 }
 
 export const instanceStatuses: ClusterInstanceStatus[] = [

--- a/ui/src/util/clusterWarnings.tsx
+++ b/ui/src/util/clusterWarnings.tsx
@@ -4,11 +4,16 @@ import { getMinutesSinceLastHeartbeat, pluralize } from "util/helpers";
 export const getClusterWarnings = (cluster: Cluster): string[] => {
   const result: string[] = [];
 
-  const diskUsagePercent =
-    (100 / cluster.disk_total_size) * cluster.disk_usage || 0;
-  if (diskUsagePercent > cluster.disk_threshold) {
-    result.push(`Disk usage is at ${Math.ceil(diskUsagePercent)}%`);
-  }
+  cluster.storage_pool_usages.forEach((pool) => {
+    const usagePercent = (100 / pool.total) * pool.usage || 0;
+    const memberSuffix = pool.member !== "" ? ` on ${pool.member}` : "";
+
+    if (usagePercent > cluster.disk_threshold) {
+      result.push(
+        `Storage pool "${pool.name}${memberSuffix}" usage is at ${Math.ceil(usagePercent)}%`,
+      );
+    }
+  });
 
   const memoryUsagePercent =
     (100 / cluster.memory_total_amount) * cluster.memory_usage || 0;


### PR DESCRIPTION
# Done
- use storage pools usage per cluster instead of total storage usage
- extend disk warning to each cluster member pool
- report details on pool usage in cluster detail page
- depends on https://github.com/canonical/microcloud/pull/1163

Fixes #343 

# Screenshots

<img width="1920" height="1046" alt="image" src="https://github.com/user-attachments/assets/5218c05c-cd93-44d8-ad8c-d50a3593fb23" />

<img width="1920" height="1046" alt="image" src="https://github.com/user-attachments/assets/2bf2bab8-5a45-490f-a394-c0b56dad98ac" />
