### PR TITLE
feat: improve storage breakdown view WD-32895

### DIFF
--- a/ui/src/pages/clusters/metrics/ClusterDiskInfo.tsx
+++ b/ui/src/pages/clusters/metrics/ClusterDiskInfo.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import type { Cluster } from "types/cluster";
-import { Icon, usePortal } from "@canonical/react-components";
+import { usePortal } from "@canonical/react-components";
 import { Link } from "react-router-dom";
 import { ClusterDiskModal } from "pages/clusters/metrics/ClusterDiskModal";
 
@@ -19,7 +19,7 @@ export const ClusterDiskInfo: FC<Props> = ({ cluster }: Props) => {
         </Portal>
       )}
       <Link onClick={openPortal} to="#">
-        <Icon name="information" />
+        <span className="p-text--small">View details</span>
       </Link>
     </>
   );


### PR DESCRIPTION
## Done
Improve cluster storage breakdown view .

## Screenshots

Before:
<img width="1887" height="970" alt="image" src="https://github.com/user-attachments/assets/0cd4afb0-c9d9-4e85-bcb9-a1052fd79926" />


After:
<img width="1913" height="954" alt="image" src="https://github.com/user-attachments/assets/37125625-bb1b-4d22-8d6f-d3464b084ab5" />
