### PR TITLE
feat: add ceph status distribution and warnings if any ceph member is not online

### DIFF
--- a/internal/app/cluster-connector/api/v1/remote_cluster.go
+++ b/internal/app/cluster-connector/api/v1/remote_cluster.go
@@ -133,6 +133,7 @@ func remoteClustersPost(rc types.RouteConfig) types.EndpointHandler {
 			// create relevant remote cluster details
 			_, err = store.CreateRemoteClusterDetail(ctx, tx, store.RemoteClusterDetail{
 				RemoteClusterID:   newRemoteCluster.ID,
+				CephStatuses:      json.RawMessage("[]"),
 				MemberStatuses:    json.RawMessage("[]"),
 				InstanceStatuses:  json.RawMessage("[]"),
 				StoragePoolUsages: json.RawMessage("[]"),
@@ -254,8 +255,8 @@ func remoteClusterStatusPost(rc types.RouteConfig) types.EndpointHandler {
 
 				err = forwardMetricsToPrometheus(timeSeries, rc)
 				if err != nil {
-					logger.Log.Warnw("Failed to forward metrics to Prometheus", "remote cluster", remoteClusterID, "err", err)
-					return fmt.Errorf("failed to forward metrics to Prometheus: %w", err)
+					logger.Log.Warnw("Failed to forward metrics to Prometheus, skipping", "remote cluster", remoteClusterID, "err", err)
+					continue
 				}
 			}
 

--- a/internal/app/management-api/api/v1/remote_cluster.go
+++ b/internal/app/management-api/api/v1/remote_cluster.go
@@ -192,8 +192,14 @@ func toRemoteClustersAPI(dbEntries []store.RemoteClusterWithDetail) ([]models.Re
 	// generate lookup for remoteCluster details
 	var remoteClusters []models.RemoteCluster
 	for _, e := range dbEntries {
+		var cephStatuses []models.StatusDistribution
+		err := json.Unmarshal(e.CephStatuses, &cephStatuses)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal ceph statuses: %w", err)
+		}
+
 		var memberStatuses []models.StatusDistribution
-		err := json.Unmarshal(e.MemberStatuses, &memberStatuses)
+		err = json.Unmarshal(e.MemberStatuses, &memberStatuses)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal member statuses: %w", err)
 		}
@@ -217,6 +223,8 @@ func toRemoteClustersAPI(dbEntries []store.RemoteClusterWithDetail) ([]models.Re
 			DiskThreshold:      e.DiskThreshold,
 			MemoryThreshold:    e.MemoryThreshold,
 			Status:             e.Status,
+			CephCount:          e.CephCount,
+			CephStatuses:       cephStatuses,
 			CPUTotalCount:      e.CPUTotalCount,
 			CPULoad1:           e.CPULoad1,
 			CPULoad5:           e.CPULoad5,

--- a/internal/pkg/api/models/v1/remote_cluster.go
+++ b/internal/pkg/api/models/v1/remote_cluster.go
@@ -39,6 +39,8 @@ type RemoteCluster struct {
 	DiskThreshold      int64                `json:"disk_threshold"`
 	MemoryThreshold    int64                `json:"memory_threshold"`
 	Status             string               `json:"status"`
+	CephCount          int64                `json:"ceph_count"`
+	CephStatuses       []StatusDistribution `json:"ceph_statuses"`
 	CPUTotalCount      int64                `json:"cpu_total_count"`
 	CPULoad1           string               `json:"cpu_load_1"`
 	CPULoad5           string               `json:"cpu_load_5"`
@@ -71,8 +73,9 @@ type RemoteClusterPost struct {
 	Token              string `json:"token" yaml:"token"`
 }
 
-// RemoteClusterStatusPost is sent by LXD with to inform about its current status.
+// RemoteClusterStatusPost is sent by LXD to inform about its current status.
 type RemoteClusterStatusPost struct {
+	CephStatuses      []StatusDistribution `json:"ceph_statuses"`
 	CPUTotalCount     int64                `json:"cpu_total_count"`
 	CPULoad1          string               `json:"cpu_load_1"`
 	CPULoad5          string               `json:"cpu_load_5"`

--- a/internal/pkg/database/schema/migrations/00001_db.sql
+++ b/internal/pkg/database/schema/migrations/00001_db.sql
@@ -42,6 +42,8 @@ CREATE INDEX IF NOT EXISTS idx_remote_cluster_tokens_name ON remote_cluster_toke
 CREATE TABLE IF NOT EXISTS remote_cluster_details (
     id SERIAL PRIMARY KEY,
     remote_cluster_id INTEGER NOT NULL UNIQUE REFERENCES remote_clusters(id) ON DELETE CASCADE,
+    ceph_count INTEGER NOT NULL DEFAULT 0,
+    ceph_statuses JSONB NOT NULL DEFAULT '[]'::JSONB,
     cpu_total_count BIGINT NOT NULL DEFAULT 0,
     cpu_load_1 TEXT NOT NULL DEFAULT 0,
     cpu_load_5 TEXT NOT NULL DEFAULT 0,

--- a/internal/pkg/database/seed/seed.go
+++ b/internal/pkg/database/seed/seed.go
@@ -291,8 +291,15 @@ func generateRemoteClusterDetails(count int) ([]store.RemoteClusterDetail, error
 			return nil, fmt.Errorf("failed to generate member statuses: %w", err)
 		}
 
+		cephStatuses, err := generateRandomStatuses("ONLINE", "UNAVAILABLE", "FOO", "BAR", totalMembers)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate ceph statuses: %w", err)
+		}
+
 		clusters[i] = store.RemoteClusterDetail{
 			RemoteClusterID:   i + 1,
+			CephCount:         totalMembers,
+			CephStatuses:      cephStatuses,
 			CPUTotalCount:     rand.Int64N(32) + 1, // Random CPU count between 1 and 32
 			CPULoad1:          fmt.Sprintf("%.1f", rand.Float64()),
 			CPULoad5:          fmt.Sprintf("%.1f", rand.Float64()),
@@ -327,31 +334,35 @@ func seedRemoteClusterDetails(ctx context.Context, db *database.DB) error {
 		for idx, detail := range remoteClusterDetails {
 			q := `
 				INSERT INTO remote_cluster_details 
-					(remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, instance_count, instance_statuses, member_count, member_statuses, storage_pool_usages)
+					(remote_cluster_id, ceph_count, ceph_statuses, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, instance_count, instance_statuses, member_count, member_statuses, storage_pool_usages)
 				VALUES 
-					($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+					($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 				ON CONFLICT (remote_cluster_id)
 				DO UPDATE SET
 					remote_cluster_id = $1,
-					cpu_total_count = $2,
-					cpu_load_1 = $3,
-					cpu_load_5 = $4,
-					cpu_load_15 = $5,
-					memory_total_amount = $6,
-					memory_usage = $7,
-					instance_count = $8,
-					instance_statuses = $9,
-					member_count = $10,
-					member_statuses = $11,
-				    storage_pool_usages = $12
+				    ceph_count = $2,
+				    ceph_statuses = $3,
+					cpu_total_count = $4,
+					cpu_load_1 = $5,
+					cpu_load_5 = $6,
+					cpu_load_15 = $7,
+					memory_total_amount = $8,
+					memory_usage = $9,
+					instance_count = $10,
+					instance_statuses = $11,
+					member_count = $12,
+					member_statuses = $13,
+				    storage_pool_usages = $14
 				RETURNING 
-					id, remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, instance_count, instance_statuses, member_count, member_statuses, storage_pool_usages, created_at, updated_at;
+					id, remote_cluster_id, ceph_count, ceph_statuses, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, instance_count, instance_statuses, member_count, member_statuses, storage_pool_usages, created_at, updated_at;
 			`
 
 			detail.RemoteClusterID = clusters[idx].ID
 			var result store.RemoteClusterDetail
 			err := tx.QueryRowContext(ctx, q,
 				detail.RemoteClusterID,
+				detail.CephCount,
+				detail.CephStatuses,
 				detail.CPUTotalCount,
 				detail.CPULoad1,
 				detail.CPULoad5,
@@ -366,6 +377,8 @@ func seedRemoteClusterDetails(ctx context.Context, db *database.DB) error {
 			).Scan(
 				&result.ID,
 				&result.RemoteClusterID,
+				&result.CephCount,
+				&result.CephStatuses,
 				&result.CPUTotalCount,
 				&result.CPULoad1,
 				&result.CPULoad5,

--- a/internal/pkg/database/store/remote_cluster_detail.go
+++ b/internal/pkg/database/store/remote_cluster_detail.go
@@ -19,6 +19,8 @@ import (
 type RemoteClusterDetail struct {
 	ID                int             `db:"id"`                    // Primary key
 	RemoteClusterID   int             `db:"remote_cluster_id"`     // Foreign key to remote_clusters
+	CephCount         int64           `db:"ceph_count"`            // Number of members
+	CephStatuses      json.RawMessage `db:"ceph_statuses"`         // JSON array of ceph statuses
 	CPUTotalCount     int64           `db:"cpu_total_count"`       // Total CPU count
 	CPULoad1          string          `db:"cpu_load_1"`            // CPU load (1 minute average)
 	CPULoad5          string          `db:"cpu_load_5"`            // CPU load (5 minute average)
@@ -37,6 +39,7 @@ type RemoteClusterDetail struct {
 
 // Put updates the RemoteClusterDetail with the provided payload.
 func (r *RemoteClusterDetail) Put(payload models.RemoteClusterStatusPost) {
+	r.CephCount, r.CephStatuses = parseStatusDistribution(payload.CephStatuses)
 	r.CPULoad1 = payload.CPULoad1
 	r.CPULoad5 = payload.CPULoad5
 	r.CPULoad15 = payload.CPULoad15
@@ -60,6 +63,8 @@ type RemoteClusterWithDetail struct {
 	MemoryThreshold    int64           `db:"memory_threshold"`
 	ClusterCreatedAt   time.Time       `db:"created_at"`
 	Status             string          `db:"status"`
+	CephCount          int64           `db:"ceph_count"`
+	CephStatuses       json.RawMessage `db:"ceph_statuses"`
 	CPUTotalCount      int64           `db:"cpu_total_count"`
 	CPULoad1           string          `db:"cpu_load_1"`
 	CPULoad5           string          `db:"cpu_load_5"`
@@ -116,7 +121,7 @@ func RemoteClusterDetailExists(ctx context.Context, tx *sqlx.Tx, remoteClusterID
 func GetRemoteClusterDetail(ctx context.Context, tx *sqlx.Tx, remoteClusterID int) (*RemoteClusterDetail, error) {
 	q := `
         SELECT 
-			id, remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, 
+			id, remote_cluster_id, ceph_count, ceph_statuses, cpu_total_count, cpu_load_1, cpu_load_5, 
 			cpu_load_15, memory_total_amount, memory_usage, 
 			instance_count, instance_statuses, member_count, 
 			member_statuses, storage_pool_usages, ui_url, created_at, updated_at
@@ -128,6 +133,8 @@ func GetRemoteClusterDetail(ctx context.Context, tx *sqlx.Tx, remoteClusterID in
 	err := tx.QueryRowContext(ctx, q, remoteClusterID).Scan(
 		&result.ID,
 		&result.RemoteClusterID,
+		&result.CephCount,
+		&result.CephStatuses,
 		&result.CPUTotalCount,
 		&result.CPULoad1,
 		&result.CPULoad5,
@@ -168,16 +175,18 @@ func CreateRemoteClusterDetail(ctx context.Context, tx *sqlx.Tx, data RemoteClus
 
 	q := `
         INSERT INTO remote_cluster_details 
-			(remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, instance_count, instance_statuses, member_count, member_statuses, storage_pool_usages, ui_url)
+			(remote_cluster_id, ceph_count, ceph_statuses, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, instance_count, instance_statuses, member_count, member_statuses, storage_pool_usages, ui_url)
         VALUES 
-			($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+			($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
         RETURNING 
-			id, remote_cluster_id, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, instance_count, instance_statuses, member_count, member_statuses, storage_pool_usages, ui_url, created_at, updated_at;
+			id, remote_cluster_id, ceph_count, ceph_statuses, cpu_total_count, cpu_load_1, cpu_load_5, cpu_load_15, memory_total_amount, memory_usage, instance_count, instance_statuses, member_count, member_statuses, storage_pool_usages, ui_url, created_at, updated_at;
     `
 
 	var result RemoteClusterDetail
 	err = tx.QueryRowContext(ctx, q,
 		data.RemoteClusterID,
+		data.CephCount,
+		data.CephStatuses,
 		data.CPUTotalCount,
 		data.CPULoad1,
 		data.CPULoad5,
@@ -193,6 +202,8 @@ func CreateRemoteClusterDetail(ctx context.Context, tx *sqlx.Tx, data RemoteClus
 	).Scan(
 		&result.ID,
 		&result.RemoteClusterID,
+		&result.CephCount,
+		&result.CephStatuses,
 		&result.CPUTotalCount,
 		&result.CPULoad1,
 		&result.CPULoad5,
@@ -225,11 +236,27 @@ func UpdateRemoteClusterDetail(ctx context.Context, tx *sqlx.Tx, remoteClusterID
 
 	q := `
         UPDATE remote_cluster_details
-        SET cpu_total_count = $1, cpu_load_1 = $2, cpu_load_5 = $3, cpu_load_15 = $4, memory_total_amount = $5, memory_usage = $6, instance_count = $7, instance_statuses = $8, member_count = $9, member_statuses = $10, storage_pool_usages = $11, ui_url = $12, updated_at = NOW()
-        WHERE id = $13;
+        SET ceph_count = $1,
+            ceph_statuses = $2,
+            cpu_total_count = $3,
+            cpu_load_1 = $4,
+            cpu_load_5 = $5,
+            cpu_load_15 = $6,
+            memory_total_amount = $7,
+            memory_usage = $8,
+            instance_count = $9,
+            instance_statuses = $10,
+            member_count = $11,
+            member_statuses = $12,
+            storage_pool_usages = $13,
+            ui_url = $14,
+            updated_at = NOW()
+        WHERE id = $15;
     `
 
 	result, err := tx.ExecContext(ctx, q,
+		data.CephCount,
+		data.CephStatuses,
 		data.CPUTotalCount,
 		data.CPULoad1,
 		data.CPULoad5,
@@ -269,6 +296,8 @@ var baseDetailQuery = `
 		remote_clusters.cluster_certificate,
 		remote_clusters.joined_at,
 		remote_clusters.created_at,
+		remote_cluster_details.ceph_count,
+		remote_cluster_details.ceph_statuses,
 		remote_cluster_details.cpu_total_count,
 		remote_cluster_details.cpu_load_1,
 		remote_cluster_details.cpu_load_5,
@@ -310,6 +339,8 @@ func getRemoteClusterWithDetails(ctx context.Context, tx *sqlx.Tx, sql string, a
 			&c.ClusterCertificate,
 			&c.ClusterJoinedAt,
 			&c.ClusterCreatedAt,
+			&c.CephCount,
+			&c.CephStatuses,
 			&c.CPUTotalCount,
 			&c.CPULoad1,
 			&c.CPULoad5,

--- a/ui/src/types/cluster.d.ts
+++ b/ui/src/types/cluster.d.ts
@@ -15,6 +15,8 @@ export interface Cluster {
   description: string;
   disk_threshold: number;
   memory_threshold: number;
+  ceph_count: number;
+  ceph_statuses: StatusDistribution[];
   cpu_total_count: number;
   cpu_load_1: string;
   cpu_load_5: string;

--- a/ui/src/util/clusterWarnings.tsx
+++ b/ui/src/util/clusterWarnings.tsx
@@ -1,5 +1,9 @@
 import type { Cluster } from "types/cluster";
-import { getMinutesSinceLastHeartbeat, pluralize } from "util/helpers";
+import {
+  capitalizeFirstLetter,
+  getMinutesSinceLastHeartbeat,
+  pluralize,
+} from "util/helpers";
 
 export const getClusterWarnings = (cluster: Cluster): string[] => {
   const result: string[] = [];
@@ -47,6 +51,17 @@ export const getClusterWarnings = (cluster: Cluster): string[] => {
       `Cluster has not sent a heartbeat in the last ${lastHeartbeatMins} minutes`,
     );
   }
+
+  cluster.ceph_statuses.forEach((cephDistribution) => {
+    const status = capitalizeFirstLetter(cephDistribution.status.toLowerCase());
+    const count = cephDistribution.count;
+    if (status === "Online" || count === 0) {
+      return;
+    }
+    result.push(
+      `Ceph has ${count} ${pluralize("member", count)} with status ${status}`,
+    );
+  });
 
   return result;
 };

--- a/ui/src/util/helpers.tsx
+++ b/ui/src/util/helpers.tsx
@@ -117,3 +117,6 @@ export const handleSettledResult = (
     throw error;
   }
 };
+
+export const capitalizeFirstLetter = (val: string): string =>
+  val.charAt(0).toUpperCase() + val.slice(1);


### PR DESCRIPTION
# Done
* Receive and store ceph status in heartbeats from the MicroClouds
* Show a warning in cluster manager if any of the ceph members of a cluster are not online

depending on https://github.com/canonical/microcloud/pull/1222

# Screenshots

<img width="3842" height="1914" alt="image" src="https://github.com/user-attachments/assets/a642370f-0b6d-4e86-9ee5-fdb6814b2da0" />


<img width="3842" height="1914" alt="image" src="https://github.com/user-attachments/assets/9559eefc-9cf9-4286-9d03-ec585d1415e5" />