### PR TITLE
Update LXD and MicroCloud docs URLs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Cluster Manager architecture
 
-See [Architecture of the MicroCloud Cluster Manager](https://documentation.ubuntu.com/microcloud/latest/microcloud/reference/cluster-manager-architecture/) for an architecture diagram and further details.
+See [Architecture of the MicroCloud Cluster Manager](https://canonical.com/microcloud/docs/latest/reference/cluster-manager-architecture/) for an architecture diagram and further details.
 
 ## Workflows
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ juju integrate self-signed-certificates:send-ca-cert microcloud-cluster-manager-
 juju integrate traefik-k8s:traefik-route microcloud-cluster-manager-k8s
 ```
 
-For authentication and authorization, you need an OIDC provider. Supported providers include Auth0, Ory Hydra, Keycloak, and Microsoft Entra. See the [LXD documentation on OIDC](https://documentation.ubuntu.com/lxd/latest/howto/oidc/) for guidance on configuring the provider side.
+For authentication and authorization, you need an OIDC provider. Supported providers include Auth0, Ory Hydra, Keycloak, and Microsoft Entra. See the [LXD documentation on OIDC](https://canonical.com/lxd/docs/latest/howto/oidc/) for guidance on configuring the provider side.
 
 On the provider side, set the OIDC callback path to `/oidc/callback`. Note that unlike LXD, Cluster Manager listens on the default port 443, so the callback URL does not need to include a port number.
 


### PR DESCRIPTION
Updates the docs URLs following the migration to:

- https://canonical.com/lxd/docs/
- https://canonical.com/microcloud/docs/

MicroCloud docs URL also updated, as the
`microcloud/latest/microcloud/...` pattern is no longer followed for the MicroCloud portion of the docs.